### PR TITLE
Add GIF keyboard support via NIP-94

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0E8A4BB72AE4359200065E81 /* NostrFilter+Hashable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8A4BB62AE4359200065E81 /* NostrFilter+Hashable.swift */; };
+		186B4E337BA36E7231BECF74 /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C75EFA327FA577B0006080F /* PostView.swift */; };
 		3165648B295B70D500C64604 /* LinkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3165648A295B70D500C64604 /* LinkView.swift */; };
 		3169CAE6294E69C000EE4006 /* EmptyTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3169CAE5294E69C000EE4006 /* EmptyTimelineView.swift */; };
 		3169CAED294FCCFC00EE4006 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3169CAEC294FCCFC00EE4006 /* Constants.swift */; };
@@ -492,6 +493,16 @@
 		50B5685329F97CB400A23243 /* CredentialHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50B5685229F97CB400A23243 /* CredentialHandler.swift */; };
 		50C3E08A2AA8E3F7006A4BC0 /* AVPlayer+Additions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50C3E0892AA8E3F7006A4BC0 /* AVPlayer+Additions.swift */; };
 		50DA11262A16A23F00236234 /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 50DA11252A16A23F00236234 /* Launch.storyboard */; };
+		557885A52EA1D4E600E24AE4 /* TenorGIFProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557885A02EA1D4E600E24AE4 /* TenorGIFProvider.swift */; };
+		557885A62EA1D4E600E24AE4 /* FileMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557885992EA1D4E600E24AE4 /* FileMetadata.swift */; };
+		557885A72EA1D4E600E24AE4 /* GIFPickerItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5578859B2EA1D4E600E24AE4 /* GIFPickerItem.swift */; };
+		557885A82EA1D4E600E24AE4 /* NostrGIFProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5578859D2EA1D4E600E24AE4 /* NostrGIFProvider.swift */; };
+		557885A92EA1D4E600E24AE4 /* TenorAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5578859E2EA1D4E600E24AE4 /* TenorAPI.swift */; };
+		557885AA2EA1D4E600E24AE4 /* GIFPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5578859C2EA1D4E600E24AE4 /* GIFPickerViewModel.swift */; };
+		557885AB2EA1D4E600E24AE4 /* GIFPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557885A32EA1D4E600E24AE4 /* GIFPickerView.swift */; };
+		557885AC2EA1D4E600E24AE4 /* TenorGIF.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5578859F2EA1D4E600E24AE4 /* TenorGIF.swift */; };
+		557885AD2EA1D4E600E24AE4 /* GIFCatalogBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5578859A2EA1D4E600E24AE4 /* GIFCatalogBootstrap.swift */; };
+		557885AE2EA1D4E600E24AE4 /* GIFBootstrapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 557885A22EA1D4E600E24AE4 /* GIFBootstrapView.swift */; };
 		5C0567532C8B5F9C0073F23A /* PostingTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C8711DD2C460C06007879C2 /* PostingTimelineView.swift */; };
 		5C0567552C8B60C20073F23A /* OffsetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0567542C8B60C20073F23A /* OffsetExtension.swift */; };
 		5C0567562C8B60E60073F23A /* OffsetExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0567542C8B60C20073F23A /* OffsetExtension.swift */; };
@@ -965,7 +976,6 @@
 		82D6FC5A2CD99F7900C925F4 /* QRScanNSECView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ADFE73542AD4793100EC7326 /* QRScanNSECView.swift */; };
 		82D6FC5B2CD99F7900C925F4 /* NoteContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C363A8D28236FE4006E126D /* NoteContentView.swift */; };
 		82D6FC5C2CD99F7900C925F4 /* PostButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C75EFAC28049CFB0006080F /* PostButton.swift */; };
-		82D6FC5D2CD99F7900C925F4 /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C75EFA327FA577B0006080F /* PostView.swift */; };
 		82D6FC5E2CD99F7900C925F4 /* AttachMediaUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA876E129A00CE90003B9A3 /* AttachMediaUtility.swift */; };
 		82D6FC5F2CD99F7900C925F4 /* MediaPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = F757933929D7AECD007DEAC1 /* MediaPicker.swift */; };
 		82D6FC602CD99F7900C925F4 /* TextViewWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C83F89229A937B900136C08 /* TextViewWrapper.swift */; };
@@ -2510,6 +2520,16 @@
 		50B5685229F97CB400A23243 /* CredentialHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CredentialHandler.swift; sourceTree = "<group>"; };
 		50C3E0892AA8E3F7006A4BC0 /* AVPlayer+Additions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AVPlayer+Additions.swift"; sourceTree = "<group>"; };
 		50DA11252A16A23F00236234 /* Launch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Launch.storyboard; sourceTree = "<group>"; };
+		557885992EA1D4E600E24AE4 /* FileMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMetadata.swift; sourceTree = "<group>"; };
+		5578859A2EA1D4E600E24AE4 /* GIFCatalogBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GIFCatalogBootstrap.swift; sourceTree = "<group>"; };
+		5578859B2EA1D4E600E24AE4 /* GIFPickerItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GIFPickerItem.swift; sourceTree = "<group>"; };
+		5578859C2EA1D4E600E24AE4 /* GIFPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GIFPickerViewModel.swift; sourceTree = "<group>"; };
+		5578859D2EA1D4E600E24AE4 /* NostrGIFProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NostrGIFProvider.swift; sourceTree = "<group>"; };
+		5578859E2EA1D4E600E24AE4 /* TenorAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TenorAPI.swift; sourceTree = "<group>"; };
+		5578859F2EA1D4E600E24AE4 /* TenorGIF.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TenorGIF.swift; sourceTree = "<group>"; };
+		557885A02EA1D4E600E24AE4 /* TenorGIFProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TenorGIFProvider.swift; sourceTree = "<group>"; };
+		557885A22EA1D4E600E24AE4 /* GIFBootstrapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GIFBootstrapView.swift; sourceTree = "<group>"; };
+		557885A32EA1D4E600E24AE4 /* GIFPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GIFPickerView.swift; sourceTree = "<group>"; };
 		5C0567542C8B60C20073F23A /* OffsetExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetExtension.swift; sourceTree = "<group>"; };
 		5C0567572C8FBC560073F23A /* NDBSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NDBSearchView.swift; sourceTree = "<group>"; };
 		5C0707D02A1ECB38004E7B51 /* DamusLogoGradient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamusLogoGradient.swift; sourceTree = "<group>"; };
@@ -3938,6 +3958,30 @@
 			path = Images;
 			sourceTree = "<group>";
 		};
+		557885A12EA1D4E600E24AE4 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				557885992EA1D4E600E24AE4 /* FileMetadata.swift */,
+				5578859A2EA1D4E600E24AE4 /* GIFCatalogBootstrap.swift */,
+				5578859B2EA1D4E600E24AE4 /* GIFPickerItem.swift */,
+				5578859C2EA1D4E600E24AE4 /* GIFPickerViewModel.swift */,
+				5578859D2EA1D4E600E24AE4 /* NostrGIFProvider.swift */,
+				5578859E2EA1D4E600E24AE4 /* TenorAPI.swift */,
+				5578859F2EA1D4E600E24AE4 /* TenorGIF.swift */,
+				557885A02EA1D4E600E24AE4 /* TenorGIFProvider.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		557885A42EA1D4E600E24AE4 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				557885A22EA1D4E600E24AE4 /* GIFBootstrapView.swift */,
+				557885A32EA1D4E600E24AE4 /* GIFPickerView.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		5C78A7752E22F84A00CF177D /* Core */ = {
 			isa = PBXGroup;
 			children = (
@@ -3986,6 +4030,8 @@
 		5C78A7792E22FDFE00CF177D /* Features */ = {
 			isa = PBXGroup;
 			children = (
+				557885A12EA1D4E600E24AE4 /* Models */,
+				557885A42EA1D4E600E24AE4 /* Views */,
 				5C78A7BC2E304D7400CF177D /* Translations */,
 				5C78A7B52E3046F400CF177D /* NIP05 */,
 				5C78A7AA2E30428D00CF177D /* Actions */,
@@ -5440,6 +5486,16 @@
 				F757933A29D7AECD007DEAC1 /* MediaPicker.swift in Sources */,
 				4CC6AA752CAB688500989CEF /* str.c in Sources */,
 				4CC6AA762CAB688500989CEF /* tal.c in Sources */,
+				557885A52EA1D4E600E24AE4 /* TenorGIFProvider.swift in Sources */,
+				557885A62EA1D4E600E24AE4 /* FileMetadata.swift in Sources */,
+				557885A72EA1D4E600E24AE4 /* GIFPickerItem.swift in Sources */,
+				557885A82EA1D4E600E24AE4 /* NostrGIFProvider.swift in Sources */,
+				557885A92EA1D4E600E24AE4 /* TenorAPI.swift in Sources */,
+				557885AA2EA1D4E600E24AE4 /* GIFPickerViewModel.swift in Sources */,
+				557885AB2EA1D4E600E24AE4 /* GIFPickerView.swift in Sources */,
+				557885AC2EA1D4E600E24AE4 /* TenorGIF.swift in Sources */,
+				557885AD2EA1D4E600E24AE4 /* GIFCatalogBootstrap.swift in Sources */,
+				557885AE2EA1D4E600E24AE4 /* GIFBootstrapView.swift in Sources */,
 				4CC6AA782CAB688500989CEF /* mem.c in Sources */,
 				4CC6AA792CAB688500989CEF /* sha256.c in Sources */,
 				4CC6AA7B2CAB688500989CEF /* likely.c in Sources */,
@@ -6464,7 +6520,6 @@
 				82D6FC5B2CD99F7900C925F4 /* NoteContentView.swift in Sources */,
 				82D6FC5C2CD99F7900C925F4 /* PostButton.swift in Sources */,
 				5CB017322D4422DB00A9ED05 /* NWCSettings.swift in Sources */,
-				82D6FC5D2CD99F7900C925F4 /* PostView.swift in Sources */,
 				82D6FC5E2CD99F7900C925F4 /* AttachMediaUtility.swift in Sources */,
 				82D6FC5F2CD99F7900C925F4 /* MediaPicker.swift in Sources */,
 				82D6FC602CD99F7900C925F4 /* TextViewWrapper.swift in Sources */,
@@ -6497,6 +6552,7 @@
 				82D6FC7B2CD99F7900C925F4 /* TestData.swift in Sources */,
 				82D6FC7C2CD99F7900C925F4 /* ContentParsing.swift in Sources */,
 				82D6FC7D2CD99F7900C925F4 /* NotificationFormatter.swift in Sources */,
+				186B4E337BA36E7231BECF74 /* PostView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -7670,6 +7726,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
+					"APPEXTENSION=1",
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "share extension/Info.plist";
@@ -7682,6 +7739,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DAPPEXTENSION";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jb55.damus2.share-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -7703,6 +7761,10 @@
 				DEVELOPMENT_TEAM = XK7H4JAB3D;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"APPEXTENSION=1",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "share extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "share extension";
@@ -7714,6 +7776,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DAPPEXTENSION";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jb55.damus2.share-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -7735,6 +7798,10 @@
 				DEVELOPMENT_TEAM = XK7H4JAB3D;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"APPEXTENSION=1",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "highlighter action extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Highlight on Damus";
@@ -7746,6 +7813,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DAPPEXTENSION";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jb55.damus2.highlighter-action-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -7768,6 +7836,10 @@
 				DEVELOPMENT_TEAM = XK7H4JAB3D;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"APPEXTENSION=1",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "highlighter action extension/Info.plist";
 				INFOPLIST_KEY_CFBundleDisplayName = "Highlight on Damus";
@@ -7779,6 +7851,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DAPPEXTENSION";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.jb55.damus2.highlighter-action-extension";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -7800,6 +7873,10 @@
 				DEVELOPMENT_TEAM = XK7H4JAB3D;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"APPEXTENSION=1",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DamusNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = DamusNotificationService;
@@ -7811,6 +7888,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DAPPEXTENSION";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jb55.damus2.DamusNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -7833,6 +7911,10 @@
 				DEVELOPMENT_TEAM = XK7H4JAB3D;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"APPEXTENSION=1",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = DamusNotificationService/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = DamusNotificationService;
@@ -7844,6 +7926,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				OTHER_SWIFT_FLAGS = "$(inherited) -DAPPEXTENSION";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jb55.damus2.DamusNotificationService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/damus/Core/Nostr/NostrKind.swift
+++ b/damus/Core/Nostr/NostrKind.swift
@@ -32,4 +32,5 @@ enum NostrKind: UInt32, Codable {
     case http_auth = 27235
     case status = 30315
     case follow_list = 39089
+    case file_metadata = 1063
 }

--- a/damus/Features/Events/Models/LoadableNostrEventView.swift
+++ b/damus/Features/Events/Models/LoadableNostrEventView.swift
@@ -74,7 +74,7 @@ class LoadableNostrEventViewModel: ObservableObject {
             case .zap, .zap_request:
                 guard let zap = await get_zap(from: ev, state: damus_state) else { return .not_found }
                 return .loaded(route: Route.Zaps(target: zap.target))
-            case .contacts, .metadata, .delete, .boost, .chat, .mute_list, .list_deprecated, .draft, .longform, .nwc_request, .nwc_response, .http_auth, .status, .relay_list, .follow_list, .interest_list:
+            case .contacts, .metadata, .delete, .boost, .chat, .mute_list, .list_deprecated, .draft, .longform, .nwc_request, .nwc_response, .http_auth, .status, .relay_list, .follow_list, .interest_list, .file_metadata:
                 return .unknown_or_unsupported_kind
             }
         case .naddr(let naddr):

--- a/damus/Features/Models/FileMetadata.swift
+++ b/damus/Features/Models/FileMetadata.swift
@@ -1,0 +1,317 @@
+//
+//  FileMetadata.swift
+//  damus
+//
+//  NIP-94 File Metadata
+//  https://github.com/nostr-protocol/nips/blob/master/94.md
+//
+
+import Foundation
+
+/// Represents NIP-94 file metadata
+struct FileMetadata: Equatable {
+    struct RemoteResource: Equatable {
+        let url: URL
+        let sha256: String?
+    }
+
+    let url: URL
+    let mimeType: String
+    let sha256: String?
+    let originalSha256: String?
+    let size: Int?
+    let dimensions: ImageMetaDim?
+    let magnetURI: String?
+    let infoHash: String?
+    let blurhash: String?
+    let thumbnail: RemoteResource?
+    let image: RemoteResource?
+    let summary: String?
+    let alt: String?
+    let fallbacks: [URL]
+    let service: String?
+    let eventId: NoteId?
+    let author: Pubkey?
+    let relayHints: [RelayURL]
+    let publishedAt: UInt32?
+
+    init(
+        url: URL,
+        mimeType: String = "image/gif",
+        sha256: String? = nil,
+        originalSha256: String? = nil,
+        size: Int? = nil,
+        dimensions: ImageMetaDim? = nil,
+        magnetURI: String? = nil,
+        infoHash: String? = nil,
+        blurhash: String? = nil,
+        thumbnail: RemoteResource? = nil,
+        image: RemoteResource? = nil,
+        summary: String? = nil,
+        alt: String? = nil,
+        fallbacks: [URL] = [],
+        service: String? = nil,
+        eventId: NoteId? = nil,
+        author: Pubkey? = nil,
+        relayHints: [RelayURL] = [],
+        publishedAt: UInt32? = nil
+    ) {
+        self.url = url
+        self.mimeType = mimeType
+        self.sha256 = sha256
+        self.originalSha256 = originalSha256
+        self.size = size
+        self.dimensions = dimensions
+        self.magnetURI = magnetURI
+        self.infoHash = infoHash
+        self.blurhash = blurhash
+        self.thumbnail = thumbnail
+        self.image = image
+        self.summary = summary
+        self.alt = alt
+        self.fallbacks = fallbacks
+        self.service = service
+        self.eventId = eventId
+        self.author = author
+        self.relayHints = relayHints
+        self.publishedAt = publishedAt
+    }
+
+    func updating(
+        eventId: NoteId? = nil,
+        author: Pubkey? = nil,
+        publishedAt: UInt32? = nil,
+        relayHints: [RelayURL]? = nil,
+        alt: String? = nil,
+        summary: String? = nil
+    ) -> FileMetadata {
+        FileMetadata(
+            url: url,
+            mimeType: mimeType,
+            sha256: sha256,
+            originalSha256: originalSha256,
+            size: size,
+            dimensions: dimensions,
+            magnetURI: magnetURI,
+            infoHash: infoHash,
+            blurhash: blurhash,
+            thumbnail: thumbnail,
+            image: image,
+            summary: summary ?? self.summary,
+            alt: alt ?? self.alt,
+            fallbacks: fallbacks,
+            service: service,
+            eventId: eventId ?? self.eventId,
+            author: author ?? self.author,
+            relayHints: relayHints ?? self.relayHints,
+            publishedAt: publishedAt ?? self.publishedAt
+        )
+    }
+
+    var previewURL: URL? {
+        return thumbnail?.url ?? image?.url ?? url
+    }
+
+    /// Convert to ImageMetadata for compatibility with damus's existing media system
+    func toImageMetadata() -> ImageMetadata {
+        return ImageMetadata(
+            url: url,
+            blurhash: blurhash,
+            dim: dimensions
+        )
+    }
+
+    func toTags() -> [[String]] {
+        var tags: [[String]] = [
+            ["url", url.absoluteString],
+            ["m", mimeType]
+        ]
+
+        if let sha256 {
+            tags.append(["x", sha256])
+        }
+        if let originalSha256 {
+            tags.append(["ox", originalSha256])
+        }
+        if let size {
+            tags.append(["size", String(size)])
+        }
+        if let dimensions {
+            tags.append(["dim", dimensions.to_string()])
+        }
+        if let magnetURI {
+            tags.append(["magnet", magnetURI])
+        }
+        if let infoHash {
+            tags.append(["i", infoHash])
+        }
+        if let blurhash {
+            tags.append(["blurhash", blurhash])
+        }
+        if let summary {
+            tags.append(["summary", summary])
+        }
+        if let alt {
+            tags.append(["alt", alt])
+        }
+        if let service {
+            tags.append(["service", service])
+        }
+        if let thumb = thumbnail {
+            var thumbTag = ["thumb", thumb.url.absoluteString]
+            if let sha = thumb.sha256 {
+                thumbTag.append(sha)
+            }
+            tags.append(thumbTag)
+        }
+        if let image = image {
+            var imageTag = ["image", image.url.absoluteString]
+            if let sha = image.sha256 {
+                imageTag.append(sha)
+            }
+            tags.append(imageTag)
+        }
+        for fallback in fallbacks {
+            tags.append(["fallback", fallback.absoluteString])
+        }
+
+        return tags
+    }
+
+    func toNostrEvent(
+        keypair: FullKeypair,
+        content: String = "",
+        createdAt: UInt32? = nil
+    ) -> NostrEvent? {
+        let timestamp = createdAt ?? UInt32(Date().timeIntervalSince1970)
+        return NostrEvent(
+            content: content,
+            keypair: keypair.to_keypair(),
+            kind: NostrKind.file_metadata.rawValue,
+            tags: toTags(),
+            createdAt: timestamp
+        )
+    }
+
+    static func from(event: NostrEvent, relay: RelayURL? = nil) -> FileMetadata? {
+        guard event.known_kind == .file_metadata else {
+            return nil
+        }
+        let tags = event.tags.reduce(into: [[String]]()) { result, tag in
+            result.append(tag.strings())
+        }
+
+        return FileMetadata.from(
+            tags: tags,
+            eventId: event.id,
+            author: event.pubkey,
+            publishedAt: event.created_at,
+            relayHints: relay.map { [$0] } ?? []
+        )
+    }
+
+    static func from(
+        tags: [[String]],
+        eventId: NoteId? = nil,
+        author: Pubkey? = nil,
+        publishedAt: UInt32? = nil,
+        relayHints: [RelayURL] = []
+    ) -> FileMetadata? {
+        guard
+            let urlString = tags.first(where: { $0.first == "url" })?.dropFirst().first,
+            let mimeType = tags.first(where: { $0.first == "m" })?.dropFirst().first,
+            let url = URL(string: String(urlString))
+        else {
+            return nil
+        }
+
+        var sha256: String?
+        var originalSha256: String?
+        var size: Int?
+        var dimensions: ImageMetaDim?
+        var magnet: String?
+        var infoHash: String?
+        var blurhash: String?
+        var summary: String?
+        var alt: String?
+        var thumb: RemoteResource?
+        var image: RemoteResource?
+        var fallbacks: [URL] = []
+        var service: String?
+
+        for tag in tags {
+            guard let key = tag.first else { continue }
+            switch key {
+            case "x":
+                sha256 = tag[safe: 1]
+            case "ox":
+                originalSha256 = tag[safe: 1]
+            case "size":
+                if let raw = tag[safe: 1], let value = Int(raw) {
+                    size = value
+                }
+            case "dim":
+                if let raw = tag[safe: 1] {
+                    dimensions = ImageMetaDim(from: raw)
+                }
+            case "magnet":
+                magnet = tag[safe: 1]
+            case "i":
+                infoHash = tag[safe: 1]
+            case "blurhash":
+                blurhash = tag[safe: 1]
+            case "summary":
+                summary = tag[safe: 1]
+            case "alt":
+                alt = tag[safe: 1]
+            case "service":
+                service = tag[safe: 1]
+            case "thumb":
+                if let urlString = tag[safe: 1], let thumbURL = URL(string: urlString) {
+                    thumb = RemoteResource(url: thumbURL, sha256: tag[safe: 2])
+                }
+            case "image":
+                if let urlString = tag[safe: 1], let imageURL = URL(string: urlString) {
+                    image = RemoteResource(url: imageURL, sha256: tag[safe: 2])
+                }
+            case "fallback":
+                if let urlString = tag[safe: 1], let fallbackURL = URL(string: urlString) {
+                    fallbacks.append(fallbackURL)
+                }
+            default:
+                continue
+            }
+        }
+
+        return FileMetadata(
+            url: url,
+            mimeType: String(mimeType),
+            sha256: sha256,
+            originalSha256: originalSha256,
+            size: size,
+            dimensions: dimensions,
+            magnetURI: magnet,
+            infoHash: infoHash,
+            blurhash: blurhash,
+            thumbnail: thumb,
+            image: image,
+            summary: summary,
+            alt: alt,
+            fallbacks: fallbacks,
+            service: service,
+            eventId: eventId,
+            author: author,
+            relayHints: relayHints,
+            publishedAt: publishedAt
+        )
+    }
+}
+
+private extension Array where Element == String {
+    subscript(safe index: Int) -> String? {
+        guard index >= 0 && index < count else {
+            return nil
+        }
+        return self[index]
+    }
+}

--- a/damus/Features/Models/GIFCatalogBootstrap.swift
+++ b/damus/Features/Models/GIFCatalogBootstrap.swift
@@ -1,0 +1,220 @@
+//
+//  GIFCatalogBootstrap.swift
+//  damus
+//
+//  Helper utilities for publishing curated GIF metadata events (NIP-94).
+//
+
+import Foundation
+
+enum GIFCatalogBootstrapError: Error, LocalizedError {
+    case signingFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .signingFailed:
+            return NSLocalizedString("Unable to sign metadata event.", comment: "Publishing error")
+        }
+    }
+}
+
+struct GIFCatalogEntry: Codable, Hashable {
+    let url: URL
+    let title: String
+    let description: String
+    let tags: [String]
+    let mimeType: String
+    let width: Int?
+    let height: Int?
+    let sizeInBytes: Int?
+    let thumbnailURL: URL?
+
+    init(
+        url: URL,
+        title: String,
+        description: String,
+        tags: [String],
+        mimeType: String = "image/gif",
+        width: Int? = nil,
+        height: Int? = nil,
+        sizeInBytes: Int? = nil,
+        thumbnailURL: URL? = nil
+    ) {
+        self.url = url
+        self.title = title
+        self.description = description
+        self.tags = tags
+        self.mimeType = mimeType
+        self.width = width
+        self.height = height
+        self.sizeInBytes = sizeInBytes
+        self.thumbnailURL = thumbnailURL
+    }
+
+    func toMetadata(relayHints: [RelayURL] = []) -> FileMetadata {
+        let dimensions: ImageMetaDim?
+        if let width, let height {
+            dimensions = ImageMetaDim(width: width, height: height)
+        } else {
+            dimensions = nil
+        }
+
+        let previewResource = thumbnailURL.map { FileMetadata.RemoteResource(url: $0, sha256: nil) }
+
+        return FileMetadata(
+            url: url,
+            mimeType: mimeType,
+            size: sizeInBytes,
+            dimensions: dimensions,
+            thumbnail: previewResource,
+            summary: title,
+            alt: description,
+            fallbacks: [],
+            service: "nostr",
+            relayHints: relayHints
+        )
+    }
+}
+
+enum GIFCatalogBootstrap {
+    static func getStarterCatalog() -> [GIFCatalogEntry] {
+        return [
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/OkJat1YNdoD3W/giphy.gif")!,
+                title: "Thumbs up",
+                description: "Thumbs up approval",
+                tags: ["thumbsup", "approve", "yes"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/l3q2K5jinAlChoCLS/giphy.gif")!,
+                title: "Clapping",
+                description: "Applause and clapping",
+                tags: ["clap", "cheer", "applause"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/3o6ZtaO9BZHcOjmErm/giphy.gif")!,
+                title: "Nod of agreement",
+                description: "Confident nod",
+                tags: ["nod", "agree", "yes"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/5GoVLqeAOo6PK/giphy.gif")!,
+                title: "Laughing hard",
+                description: "Laugh out loud",
+                tags: ["laugh", "lol", "funny"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/ROF8OQvDmxytW/giphy.gif")!,
+                title: "Crying",
+                description: "Tears flowing",
+                tags: ["cry", "sad", "emotion"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/l0HUpt2s9Pclgt9Vm/giphy.gif")!,
+                title: "Shocked",
+                description: "Shocked reaction",
+                tags: ["shocked", "surprised", "wow"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/3oEjI6SIIHBdRxXI40/giphy.gif")!,
+                title: "Thinking",
+                description: "Thinking face",
+                tags: ["think", "ponder", "hmm"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/13d2jHlSlxklVe/giphy.gif")!,
+                title: "Confused",
+                description: "Confused shrug",
+                tags: ["confused", "shrug", "idk"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/l46Cy1rHbQ92uuLXa/giphy.gif")!,
+                title: "Mind blown",
+                description: "Mind blown reaction",
+                tags: ["mindblown", "wow", "surprised"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/3o6wrvdHFbwBrUFenu/giphy.gif")!,
+                title: "Facepalm",
+                description: "Disappointed facepalm",
+                tags: ["facepalm", "no", "disapprove"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/26ufdipQqU2lhNA4g/giphy.gif")!,
+                title: "Shaking head",
+                description: "Shaking head disapproval",
+                tags: ["no", "disagree", "disapprove"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/3oriO7A7bt1wsEP4cw/giphy.gif")!,
+                title: "Dancing",
+                description: "Happy dancing",
+                tags: ["dance", "party", "excited"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/3o85xIO33l7RlmLR4I/giphy.gif")!,
+                title: "High five",
+                description: "Successful high five",
+                tags: ["highfive", "celebrate", "team"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/ctZDVdAXESeqY/giphy.gif")!,
+                title: "Popcorn",
+                description: "Watching with popcorn",
+                tags: ["popcorn", "watching", "drama"]
+            ),
+            GIFCatalogEntry(
+                url: URL(string: "https://media.giphy.com/media/3oz8xAFtqoOUUrsh7W/giphy.gif")!,
+                title: "Applause",
+                description: "Standing applause",
+                tags: ["applause", "bravo", "clap"]
+            )
+        ]
+    }
+
+    static func publishGIF(
+        _ entry: GIFCatalogEntry,
+        keypair: FullKeypair,
+        relayHints: [RelayURL] = []
+    ) throws -> (event: NostrEvent, metadata: FileMetadata) {
+        let metadata = entry.toMetadata(relayHints: relayHints)
+        let baseTags = metadata.toTags() + entry.tags.map { ["t", $0.lowercased()] }
+
+        guard let event = NostrEvent(
+            content: entry.description,
+            keypair: keypair.to_keypair(),
+            kind: NostrKind.file_metadata.rawValue,
+            tags: baseTags
+        ) else {
+            throw GIFCatalogBootstrapError.signingFailed
+        }
+
+        let enrichedMetadata = metadata.updating(
+            eventId: event.id,
+            author: event.pubkey,
+            publishedAt: event.created_at,
+            relayHints: relayHints
+        )
+
+        return (event, enrichedMetadata)
+    }
+
+    static func batchPublishGIFs(
+        _ entries: [GIFCatalogEntry],
+        keypair: FullKeypair,
+        postbox: PostBox? = nil,
+        relayHints: [RelayURL] = [],
+        progress: ((Int, Int) -> Void)? = nil
+    ) async throws -> [NostrEvent] {
+        var events: [NostrEvent] = []
+        for (index, entry) in entries.enumerated() {
+            try Task.checkCancellation()
+            let (event, _) = try publishGIF(entry, keypair: keypair, relayHints: relayHints)
+            events.append(event)
+            postbox?.send(event)
+            progress?(index + 1, entries.count)
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return events
+    }
+}

--- a/damus/Features/Models/GIFPickerItem.swift
+++ b/damus/Features/Models/GIFPickerItem.swift
@@ -1,0 +1,58 @@
+//
+//  GIFPickerItem.swift
+//  damus
+//
+//  Represents a unified GIF item surfaced in the picker, regardless of source.
+//
+
+import Foundation
+
+struct GIFPickerItem: Identifiable {
+    enum ProviderSource: String {
+        case nostr
+        case tenor
+    }
+
+    let id: String
+    let title: String
+    let description: String?
+    let metadata: FileMetadata
+    let previewURL: URL?
+    let provider: ProviderSource
+    let attribution: String?
+
+    init(
+        id: String,
+        title: String,
+        description: String? = nil,
+        metadata: FileMetadata,
+        previewURL: URL?,
+        provider: ProviderSource,
+        attribution: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.description = description
+        self.metadata = metadata
+        self.previewURL = previewURL
+        self.provider = provider
+        self.attribution = attribution
+    }
+
+    var displayTitle: String {
+        if !title.isEmpty {
+            return title
+        }
+        if let description, !description.isEmpty {
+            return description
+        }
+        if let alt = metadata.alt, !alt.isEmpty {
+            return alt
+        }
+        return metadata.url.lastPathComponent
+    }
+
+    var fallbackAlt: String? {
+        return metadata.alt ?? description ?? title
+    }
+}

--- a/damus/Features/Models/GIFPickerViewModel.swift
+++ b/damus/Features/Models/GIFPickerViewModel.swift
@@ -1,0 +1,112 @@
+//
+//  GIFPickerViewModel.swift
+//  damus
+//
+//  Drives the GIF picker UI with pluggable providers.
+//
+
+import Foundation
+
+@MainActor
+final class GIFPickerViewModel: ObservableObject {
+    enum Provider: String, CaseIterable, Identifiable {
+        case nostr
+        case tenor
+
+        var id: String { rawValue }
+
+        var title: String {
+            switch self {
+            case .nostr: return "Nostr"
+            case .tenor: return "Tenor"
+            }
+        }
+    }
+
+    @Published var searchText: String = ""
+    @Published var items: [GIFPickerItem] = []
+    @Published var isLoading: Bool = false
+    @Published var error: String?
+    @Published var activeProvider: Provider {
+        didSet {
+            Task {
+                await loadFeatured()
+            }
+        }
+    }
+
+    private let nostrProvider: NostrGIFProvider
+    private let tenorProvider: TenorGIFProvider
+    private var loadTask: Task<Void, Never>?
+
+    init(damusState: DamusState, defaultProvider: Provider = .nostr) {
+        self.nostrProvider = NostrGIFProvider(damusState: damusState)
+        self.tenorProvider = TenorGIFProvider()
+        self.activeProvider = defaultProvider
+
+        loadTask = Task {
+            await loadFeatured()
+        }
+    }
+
+    func loadFeatured() async {
+        loadTask?.cancel()
+        loadTask = Task {
+            await fetchResults { [self] in
+                switch self.activeProvider {
+                case .nostr:
+                    return try await self.nostrProvider.featured(limit: 30)
+                case .tenor:
+                    return try await self.tenorProvider.featured(limit: 30)
+                }
+            }
+        }
+        await loadTask?.value
+    }
+
+    func performSearch() async {
+        let trimmed = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            await loadFeatured()
+            return
+        }
+
+        loadTask?.cancel()
+        loadTask = Task {
+            await fetchResults { [self] in
+                switch self.activeProvider {
+                case .nostr:
+                    return try await self.nostrProvider.search(query: trimmed, limit: 30)
+                case .tenor:
+                    return try await self.tenorProvider.search(query: trimmed, limit: 30)
+                }
+            }
+        }
+        await loadTask?.value
+    }
+
+    func clearSearch() {
+        searchText = ""
+        Task {
+            await loadFeatured()
+        }
+    }
+
+    private func fetchResults(
+        _ producer: @escaping () async throws -> [GIFPickerItem]
+    ) async {
+        isLoading = true
+        error = nil
+
+        do {
+            let results = try await producer()
+            items = results
+        } catch {
+            items = []
+            if Task.isCancelled { return }
+            self.error = error.localizedDescription
+        }
+
+        isLoading = false
+    }
+}

--- a/damus/Features/Models/NostrGIFProvider.swift
+++ b/damus/Features/Models/NostrGIFProvider.swift
@@ -1,0 +1,108 @@
+//
+//  NostrGIFProvider.swift
+//  damus
+//
+//  Fetches GIF metadata from Nostr relays (NIP-94, kind 1063).
+//
+
+import Foundation
+
+final class NostrGIFProvider {
+    private let damusState: DamusState
+
+    init(damusState: DamusState) {
+        self.damusState = damusState
+    }
+
+    func featured(limit: Int = 30) async throws -> [GIFPickerItem] {
+        await fetch(limit: limit, query: nil)
+    }
+
+    func search(query: String, limit: Int = 30) async throws -> [GIFPickerItem] {
+        await fetch(limit: limit, query: query)
+    }
+
+    private func fetch(limit: Int, query: String?) async -> [GIFPickerItem] {
+        var items: [GIFPickerItem] = []
+        var seenIdentifiers: Set<String> = []
+        let filters = [makeFilter(limit: limit, query: query)]
+        let stream = damusState.nostrNetwork.pool.subscribe(filters: filters, eoseTimeout: 6)
+
+        for await item in stream {
+            switch item {
+            case .event(let event):
+                guard let metadata = FileMetadata.from(event: event) else {
+                    continue
+                }
+
+                let mime = metadata.mimeType.lowercased()
+                guard mime == "image/gif" || mime.hasSuffix("+gif") else {
+                    continue
+                }
+
+                if let query, !matches(query: query, event: event, metadata: metadata) {
+                    continue
+                }
+
+                let identifier = metadata.eventId?.hex() ?? metadata.url.absoluteString
+                guard !seenIdentifiers.contains(identifier) else {
+                    continue
+                }
+
+                let pickerItem = GIFPickerItem(
+                    id: identifier,
+                    title: event.content,
+                    description: metadata.summary ?? metadata.alt,
+                    metadata: metadata,
+                    previewURL: metadata.previewURL,
+                    provider: .nostr,
+                    attribution: "Nostr"
+                )
+
+                items.append(pickerItem)
+                seenIdentifiers.insert(identifier)
+
+                if items.count >= limit {
+                    return items
+                }
+            case .eose:
+                return items
+            }
+        }
+
+        return items
+    }
+
+    private func makeFilter(limit: Int, query: String?) -> NostrFilter {
+        var effectiveLimit = limit
+        if let query, !query.isEmpty {
+            // Grab a few extra results when searching so we can filter client-side.
+            effectiveLimit = limit * 3
+        }
+        return NostrFilter(kinds: [.file_metadata], limit: UInt32(effectiveLimit))
+    }
+
+    private func matches(query: String, event: NostrEvent, metadata: FileMetadata) -> Bool {
+        let needles = query.lowercased().split(separator: " ").map(String.init)
+        guard !needles.isEmpty else { return true }
+
+        var haystack: [String] = []
+        if !event.content.isEmpty { haystack.append(event.content.lowercased()) }
+        if let alt = metadata.alt?.lowercased() { haystack.append(alt) }
+        if let summary = metadata.summary?.lowercased() { haystack.append(summary) }
+        if let title = metadata.url.lastPathComponent.lowercased() as String? {
+            haystack.append(title)
+        }
+
+        let tagStrings: [String] = event.tags.reduce(into: []) { acc, tag in
+            for component in tag.strings().dropFirst() {
+                acc.append(component.lowercased())
+            }
+        }
+        haystack.append(contentsOf: tagStrings)
+
+        return needles.allSatisfy { needle in
+            haystack.contains(where: { $0.contains(needle) })
+        }
+    }
+}

--- a/damus/Features/Models/TenorAPI.swift
+++ b/damus/Features/Models/TenorAPI.swift
@@ -1,0 +1,60 @@
+//
+//  TenorAPI.swift
+//  damus
+//
+//  Tenor API client for GIF search
+//
+
+import Foundation
+
+/// Client for Tenor GIF API
+/// Note: This is optional and only used if users want to search beyond Nostr GIFs
+@MainActor
+class TenorAPI: ObservableObject {
+    static let shared = TenorAPI()
+
+    // Google's Tenor API key for testing
+    // In production, this should be configured per-user or use damus's key
+    private let apiKey = "AIzaSyAyimkuYQYF_FXVALexPuGQctUWRURdCYQ"
+    private let baseURL = "https://tenor.googleapis.com/v2"
+
+    private init() {}
+
+    /// Search for GIFs on Tenor
+    func search(query: String, limit: Int = 20) async throws -> [TenorGIF] {
+        guard !query.isEmpty else { return [] }
+
+        let encodedQuery = query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query
+
+        let urlString = "\(baseURL)/search?q=\(encodedQuery)&key=\(apiKey)&client_key=damus&limit=\(limit)&media_filter=gif"
+
+        guard let url = URL(string: urlString) else {
+            throw TenorError.invalidURL
+        }
+
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let response = try JSONDecoder().decode(TenorResponse.self, from: data)
+
+        return response.results
+    }
+
+    /// Get trending/featured GIFs
+    func featured(limit: Int = 20) async throws -> [TenorGIF] {
+        let urlString = "\(baseURL)/featured?key=\(apiKey)&client_key=damus&limit=\(limit)&media_filter=gif"
+
+        guard let url = URL(string: urlString) else {
+            throw TenorError.invalidURL
+        }
+
+        let (data, _) = try await URLSession.shared.data(from: url)
+        let response = try JSONDecoder().decode(TenorResponse.self, from: data)
+
+        return response.results
+    }
+
+    enum TenorError: Error {
+        case invalidURL
+        case networkError
+        case decodingError
+    }
+}

--- a/damus/Features/Models/TenorGIF.swift
+++ b/damus/Features/Models/TenorGIF.swift
@@ -1,0 +1,99 @@
+//
+//  TenorGIF.swift
+//  damus
+//
+//  Tenor API models for GIF search
+//
+
+import Foundation
+
+/// Represents a GIF from Tenor API
+struct TenorGIF: Identifiable, Codable {
+    let id: String
+    let title: String
+    let media_formats: MediaFormats
+    let created: Double?
+    let content_description: String
+    let itemurl: String
+    let url: String
+    let tags: [String]
+    let hasaudio: Bool
+
+    struct MediaFormats: Codable {
+        let gif: MediaFormat?
+        let tinygif: MediaFormat?
+        let nanogif: MediaFormat?
+        let mediumgif: MediaFormat?
+
+        struct MediaFormat: Codable {
+            let url: String
+            let duration: Double?
+            let preview: String?
+            let dims: [Int]?
+            let size: Int?
+        }
+    }
+
+    /// Get the best quality GIF URL
+    var fullURL: URL? {
+        if let mediumgif = media_formats.mediumgif {
+            return URL(string: mediumgif.url)
+        }
+        if let gif = media_formats.gif {
+            return URL(string: gif.url)
+        }
+        return nil
+    }
+
+    /// Get the preview/thumbnail URL
+    var previewURL: URL? {
+        if let preview = media_formats.tinygif?.url {
+            return URL(string: preview)
+        }
+        if let preview = media_formats.nanogif?.url {
+            return URL(string: preview)
+        }
+        return fullURL
+    }
+
+    /// Get dimensions if available
+    var dimensions: ImageMetaDim? {
+        if let dims = media_formats.mediumgif?.dims ?? media_formats.gif?.dims,
+           dims.count >= 2 {
+            return ImageMetaDim(width: dims[0], height: dims[1])
+        }
+        return nil
+    }
+
+    /// Convert to FileMetadata
+    func toFileMetadata() -> FileMetadata? {
+        guard let url = fullURL else { return nil }
+
+        let preview = previewURL
+        let thumbnailResource = preview.map { FileMetadata.RemoteResource(url: $0, sha256: nil) }
+        let summaryText = title.isEmpty ? nil : title
+        let altText: String?
+        if content_description.isEmpty {
+            altText = summaryText
+        } else {
+            altText = content_description
+        }
+        return FileMetadata(
+            url: url,
+            mimeType: "image/gif",
+            size: media_formats.mediumgif?.size ?? media_formats.gif?.size,
+            dimensions: dimensions,
+            thumbnail: thumbnailResource,
+            image: nil,
+            summary: summaryText,
+            alt: altText,
+            service: "tenor"
+        )
+    }
+}
+
+/// Tenor API response wrapper
+struct TenorResponse: Codable {
+    let results: [TenorGIF]
+    let next: String?
+}

--- a/damus/Features/Models/TenorGIFProvider.swift
+++ b/damus/Features/Models/TenorGIFProvider.swift
@@ -1,0 +1,43 @@
+//
+//  TenorGIFProvider.swift
+//  damus
+//
+//  Lightweight wrapper that converts Tenor API responses into picker items.
+//
+
+import Foundation
+
+@MainActor
+final class TenorGIFProvider {
+    private let api: TenorAPI
+
+    init(api: TenorAPI = .shared) {
+        self.api = api
+    }
+
+    func featured(limit: Int = 30) async throws -> [GIFPickerItem] {
+        let gifs = try await api.featured(limit: limit)
+        return gifs.compactMap(makeItem(from:))
+    }
+
+    func search(query: String, limit: Int = 30) async throws -> [GIFPickerItem] {
+        let gifs = try await api.search(query: query, limit: limit)
+        return gifs.compactMap(makeItem(from:))
+    }
+
+    private func makeItem(from gif: TenorGIF) -> GIFPickerItem? {
+        guard let metadata = gif.toFileMetadata() else {
+            return nil
+        }
+
+        return GIFPickerItem(
+            id: gif.id,
+            title: gif.title,
+            description: gif.content_description,
+            metadata: metadata,
+            previewURL: gif.previewURL,
+            provider: .tenor,
+            attribution: "Tenor"
+        )
+    }
+}

--- a/damus/Features/Posting/Models/DraftsModel.swift
+++ b/damus/Features/Posting/Models/DraftsModel.swift
@@ -141,7 +141,7 @@ class DraftArtifacts: Equatable {
                 if isSupportedImage(url: url) {
                     // Image, add that to our media attachments
                     // TODO: Add metadata decoding support
-                    media.append(UploadedMedia(localURL: url, uploadedURL: url, metadata: .none))
+                    media.append(UploadedMedia(localURL: url, uploadedURL: url, metadata: .none, fileMetadata: nil))
                     continue
                 }
                 else {

--- a/damus/Features/Timeline/Models/HomeModel.swift
+++ b/damus/Features/Timeline/Models/HomeModel.swift
@@ -231,6 +231,8 @@ class HomeModel: ContactsDelegate {
             break
         case .interest_list:
             break   // Don't care for now
+        case .file_metadata:
+            break   // File metadata events (NIP-94) - not processed in timeline
         }
     }
 

--- a/damus/Features/Views/GIFBootstrapView.swift
+++ b/damus/Features/Views/GIFBootstrapView.swift
@@ -1,0 +1,131 @@
+//
+//  GIFBootstrapView.swift
+//  damus
+//
+//  Simple UI for publishing the starter GIF catalog to Nostr.
+//
+
+import SwiftUI
+
+struct GIFBootstrapView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    let damus_state: DamusState
+
+    @State private var isPublishing = false
+    @State private var progressValue: (current: Int, total: Int)?
+    @State private var errorMessage: String?
+    @State private var publishedEventIds: [NoteId] = []
+
+    var body: some View {
+        NavigationView {
+            VStack(alignment: .leading, spacing: 16) {
+                Text("Bootstrap the community GIF catalog by publishing a curated starter set of reactions to your relays.")
+                    .font(.callout)
+                    .foregroundColor(.secondary)
+
+                if let progressValue {
+                    ProgressView(value: Double(progressValue.current), total: Double(progressValue.total))
+                        .accessibilityLabel("Publishing progress")
+                    Text("Publishing GIF \(progressValue.current) of \(progressValue.total)…")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                }
+
+                if !publishedEventIds.isEmpty {
+                    Text("Published events")
+                        .font(.headline)
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: 6) {
+                            ForEach(publishedEventIds, id: \.self) { noteId in
+                                Text(noteId.hex())
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .padding(8)
+                                    .frame(maxWidth: .infinity, alignment: .leading)
+                                    .background(Color(.secondarySystemBackground))
+                                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                            }
+                        }
+                        .padding(.vertical, 4)
+                    }
+                    .frame(maxHeight: 180)
+                }
+
+                if let errorMessage {
+                    Text(errorMessage)
+                        .foregroundColor(.red)
+                        .font(.footnote)
+                }
+
+                Spacer()
+
+                Button(action: startPublishing) {
+                    if isPublishing {
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text("Publish Starter Catalog")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(isPublishing)
+            }
+            .padding()
+            .navigationTitle("GIF Catalog")
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Close") { dismiss() }
+                }
+            }
+        }
+    }
+
+    private func startPublishing() {
+        guard !isPublishing else { return }
+        guard let keypair = damus_state.keypair.to_full() else {
+            errorMessage = NSLocalizedString("A private key is required to publish GIF metadata.", comment: "Bootstrap error")
+            return
+        }
+
+        isPublishing = true
+        errorMessage = nil
+        publishedEventIds = []
+        progressValue = (0, GIFCatalogBootstrap.getStarterCatalog().count)
+
+        let entries = GIFCatalogBootstrap.getStarterCatalog()
+        let postbox = damus_state.nostrNetwork.postbox
+        let relayHints = damus_state.nostrNetwork.pool.our_descriptors.map { $0.url }
+
+        Task {
+            do {
+                let events = try await GIFCatalogBootstrap.batchPublishGIFs(
+                    entries,
+                    keypair: keypair,
+                    postbox: postbox,
+                    relayHints: relayHints
+                ) { current, total in
+                    Task { @MainActor in
+                        progressValue = (current, total)
+                    }
+                }
+
+                await MainActor.run {
+                    publishedEventIds = events.map { $0.id }
+                    isPublishing = false
+                }
+            } catch {
+                await MainActor.run {
+                    isPublishing = false
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    GIFBootstrapView(damus_state: test_damus_state)
+}

--- a/damus/Features/Views/GIFPickerView.swift
+++ b/damus/Features/Views/GIFPickerView.swift
@@ -1,0 +1,179 @@
+//
+//  GIFPickerView.swift
+//  damus
+//
+//  GIF picker interface for selecting GIFs from Nostr or Tenor.
+//
+
+import SwiftUI
+import Kingfisher
+
+struct GIFPickerView: View {
+    @StateObject private var viewModel: GIFPickerViewModel
+    @Environment(\.dismiss) var dismiss
+
+    let onSelect: (GIFPickerItem) -> Void
+
+    private let columns = [
+        GridItem(.flexible(), spacing: 8),
+        GridItem(.flexible(), spacing: 8)
+    ]
+
+    init(damusState: DamusState, onSelect: @escaping (GIFPickerItem) -> Void) {
+        _viewModel = StateObject(wrappedValue: GIFPickerViewModel(damusState: damusState))
+        self.onSelect = onSelect
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                providerPicker
+                    .padding(.top, 12)
+                    .padding(.horizontal)
+                searchBar
+
+                if let error = viewModel.error {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .padding(.horizontal)
+                        .padding(.bottom, 8)
+                }
+
+                if viewModel.isLoading && viewModel.items.isEmpty {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                } else {
+                    ScrollView {
+                        if viewModel.items.isEmpty {
+                            VStack(spacing: 12) {
+                                Image(systemName: "photo.on.rectangle.angled")
+                                    .font(.system(size: 42))
+                                    .foregroundColor(.secondary)
+                                Text("No GIFs found")
+                                    .font(.footnote)
+                                    .foregroundColor(.secondary)
+                            }
+                            .frame(maxWidth: .infinity, minHeight: 200)
+                            .padding()
+                        } else {
+                            LazyVGrid(columns: columns, spacing: 8) {
+                                ForEach(viewModel.items) { item in
+                                    GIFCell(item: item) {
+                                        onSelect(item)
+                                        dismiss()
+                                    }
+                                }
+                            }
+                            .padding(8)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Select GIF")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private var providerPicker: some View {
+        Picker("Provider", selection: $viewModel.activeProvider) {
+            ForEach(GIFPickerViewModel.Provider.allCases) { provider in
+                Text(provider.title).tag(provider)
+            }
+        }
+        .pickerStyle(.segmented)
+    }
+
+    private var searchBar: some View {
+        HStack {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(.gray)
+
+            TextField("Search GIFs...", text: $viewModel.searchText)
+                .textFieldStyle(.plain)
+                .autocapitalization(.none)
+                .disableAutocorrection(true)
+                .onSubmit {
+                    Task {
+                        await viewModel.performSearch()
+                    }
+                }
+
+            if !viewModel.searchText.isEmpty {
+                Button(action: {
+                    viewModel.clearSearch()
+                }) {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(.gray)
+                }
+            }
+        }
+        .padding(10)
+        .background(Color(.systemGray6))
+        .cornerRadius(10)
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+    }
+}
+
+private struct GIFCell: View {
+    let item: GIFPickerItem
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            if let previewURL = item.previewURL {
+                KFAnimatedImage(previewURL)
+                    .imageContext(.note, disable_animation: false)
+                    .configure { view in
+                        view.framePreloadCount = 3
+                    }
+                    .aspectRatio(contentMode: .fill)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 150)
+                    .clipped()
+                    .cornerRadius(8)
+            } else {
+                Rectangle()
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(height: 150)
+                    .cornerRadius(8)
+                    .overlay(
+                        VStack(spacing: 6) {
+                            Image(systemName: "photo")
+                                .foregroundColor(.gray)
+                            Text(item.displayTitle)
+                                .font(.caption)
+                                .multilineTextAlignment(.center)
+                                .foregroundColor(.gray)
+                        }
+                        .padding(8)
+                    )
+            }
+        }
+        .buttonStyle(.plain)
+        .overlay(alignment: .bottomLeading) {
+            if let attribution = item.attribution {
+                Text(attribution)
+                    .font(.caption2)
+                    .padding(4)
+                    .background(Color.black.opacity(0.5))
+                    .foregroundColor(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .padding(6)
+            }
+        }
+    }
+}
+
+#Preview {
+    GIFPickerView(damusState: test_damus_state) { item in
+        print("Selected: \(item.displayTitle)")
+    }
+}


### PR DESCRIPTION
## Summary\n- add NIP-94 file metadata parsing and models for GIF attachments\n- integrate Tenor search fallback and picker UI hooked into the composer\n- send metadata events and reference tags when posting GIFs, plus skip non-GIF nostr events\n\n## Testing\n- not run (Xcode build required)