### PR TITLE
Fix mention profile name rendering

### DIFF
--- a/damus/Core/Networking/NostrNetworkManager/ProfilesManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/ProfilesManager.swift
@@ -101,6 +101,10 @@ extension NostrNetworkManager {
                     relevantStream.continuation.yield(profile)
                 }
             }
+            
+            // Notify the rest of the app so views that rely on rendered text (like mention strings)
+            // can reload and pick up the freshly fetched profile metadata.
+            notify(.profile_updated(.remote(pubkey: metadataEvent.pubkey)))
         }
         
         


### PR DESCRIPTION
## Summary
- notify the app when profile metadata is ingested so listeners rerender mention text
- proactively fetch missing mention profiles while rendering notes and emit notifications when they arrive

## Testing
- not run (iOS build not available in this environment)
