### PR TITLE
Fix push notification PFP caching and bech32 fallback logging

### DIFF
--- a/DamusNotificationService/NotificationFormatter.swift
+++ b/DamusNotificationService/NotificationFormatter.swift
@@ -125,8 +125,7 @@ struct NotificationFormatter {
         let src = zap.request.ev
         let pk = zap.is_anon ? ANON_PUBKEY : src.pubkey
 
-        let profile_txn = profiles.lookup(id: pk)
-        let profile = profile_txn?.unsafeUnownedValue
+        let profile = profiles.lookup(id: pk)
         let name = Profile.displayName(profile: profile, pubkey: pk).displayName.truncate(maxLength: 50)
 
         let sats = NSNumber(value: (Double(zap.invoice.amount) / 1000.0))

--- a/DamusNotificationService/NotificationService.swift
+++ b/DamusNotificationService/NotificationService.swift
@@ -58,8 +58,7 @@ class NotificationService: UNNotificationServiceExtension {
         }
 
         let sender_profile = {
-            let txn = state.ndb.lookup_profile(nostr_event.pubkey)
-            let profile = txn?.unsafeUnownedValue?.profile
+            let profile = state.profiles.lookup(id: nostr_event.pubkey)
             let picture = ((profile?.picture.map { URL(string: $0) }) ?? URL(string: robohash(nostr_event.pubkey)))!
             return ProfileBuf(picture: picture,
                                  name: profile?.name,
@@ -186,8 +185,13 @@ func message_intent_from_note(ndb: Ndb, sender_profile: ProfileBuf, content: Str
 
     // gather recipients
     if let recipient_note_id = note.direct_replies() {
-        let replying_to = ndb.lookup_note(recipient_note_id)
-        if let replying_to_pk = replying_to?.unsafeUnownedValue?.pubkey {
+        let replying_to_pk = ndb.lookup_note(recipient_note_id, borrow: { replying_to_note -> Pubkey? in
+            switch replying_to_note {
+            case .none: return nil
+            case .some(let note): return note.pubkey
+            }
+        })
+        if let replying_to_pk {
             meta.isReplyToCurrentUser = replying_to_pk == our_pubkey
 
             if replying_to_pk != sender_pk {
@@ -247,8 +251,12 @@ func message_intent_from_note(ndb: Ndb, sender_profile: ProfileBuf, content: Str
 }
 
 func pubkey_to_inperson(ndb: Ndb, pubkey: Pubkey, our_pubkey: Pubkey) async -> INPerson {
-    let profile_txn = ndb.lookup_profile(pubkey)
-    let profile = profile_txn?.unsafeUnownedValue?.profile
+    let profile = ndb.lookup_profile(pubkey, borrow: { profileRecord in
+        switch profileRecord {
+        case .some(let pr): return pr.profile
+        case .none: return nil
+        }
+    })
     let name = profile?.name
     let display_name = profile?.display_name
     let nip05 = profile?.nip05

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -538,9 +538,7 @@ struct ContentView: View {
                     Log.debug("App background signal handling: App being backgrounded", for: .app_lifecycle)
                     let startTime = CFAbsoluteTimeGetCurrent()
                     await damus_state.nostrNetwork.handleAppBackgroundRequest()  // Close ndb streaming tasks before closing ndb to avoid memory errors
-                    Log.debug("App background signal handling: Nostr network closed after %.2f seconds", for: .app_lifecycle, CFAbsoluteTimeGetCurrent() - startTime)
-                    damus_state.ndb.close()
-                    Log.debug("App background signal handling: Ndb closed after %.2f seconds", for: .app_lifecycle, CFAbsoluteTimeGetCurrent() - startTime)
+                    Log.debug("App background signal handling: Nostr network and Ndb closed after %.2f seconds", for: .app_lifecycle, CFAbsoluteTimeGetCurrent() - startTime)
                     this_app.endBackgroundTask(bgTask)
                 }
                 break
@@ -552,9 +550,7 @@ struct ContentView: View {
                 Task {
                     await damusClosingTask?.value  // Wait for the closing task to finish before reopening things, to avoid race conditions
                     damusClosingTask = nil
-                    damus_state.ndb.reopen()
-                    // Pinging the network will automatically reconnect any dead websocket connections
-                    await damus_state.nostrNetwork.ping()
+                    await damus_state.nostrNetwork.handleAppForegroundRequest()
                 }
             @unknown default:
                 break
@@ -1143,7 +1139,6 @@ extension LossyLocalNotification {
         }
     }
 }
-
 
 func logout(_ state: DamusState?)
 {

--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -397,8 +397,7 @@ struct ContentView: View {
                 guard let ds = self.damus_state,
                       let lud16 = nwc.lud16,
                       let keypair = ds.keypair.to_full(),
-                      let profile_txn = ds.profiles.lookup(id: ds.pubkey),
-                      let profile = profile_txn.unsafeUnownedValue,
+                      let profile = ds.profiles.lookup(id: ds.pubkey),
                       lud16 != profile.lud16 else {
                     return
                 }
@@ -561,8 +560,7 @@ struct ContentView: View {
                 home.filter_events()
                 
                 guard let ds = damus_state,
-                      let profile_txn = ds.profiles.lookup(id: ds.pubkey),
-                      let profile = profile_txn.unsafeUnownedValue,
+                      let profile = ds.profiles.lookup(id: ds.pubkey),
                       let keypair = ds.keypair.to_full()
                 else {
                     return
@@ -580,8 +578,7 @@ struct ContentView: View {
             }
         }, message: {
             if case let .user(pubkey, _) = self.muting {
-                let profile_txn = damus_state!.profiles.lookup(id: pubkey)
-                let profile = profile_txn?.unsafeUnownedValue
+                let profile = damus_state!.profiles.lookup(id: pubkey)
                 let name = Profile.displayName(profile: profile, pubkey: pubkey).username.truncate(maxLength: 50)
                 Text("\(name) has been muted", comment: "Alert message that informs a user was muted.")
             } else {
@@ -643,8 +640,7 @@ struct ContentView: View {
             }
         }, message: {
             if case let .user(pubkey, _) = muting {
-                let profile_txn = damus_state?.profiles.lookup(id: pubkey)
-                let profile = profile_txn?.unsafeUnownedValue
+                let profile = damus_state?.profiles.lookup(id: pubkey)
                 let name = Profile.displayName(profile: profile, pubkey: pubkey).username.truncate(maxLength: 50)
                 Text("Mute \(name)?", comment: "Alert message prompt to ask if a user should be muted.")
             } else {

--- a/damus/Core/Networking/NostrNetworkManager/NostrNetworkManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/NostrNetworkManager.swift
@@ -59,9 +59,19 @@ class NostrNetworkManager {
         await self.pool.disconnect()
     }
     
-    func handleAppBackgroundRequest() async {
+    func handleAppBackgroundRequest(beforeClosingNdb operationBeforeClosingNdb: (() async -> Void)? = nil) async {
+        // Mark NDB as closed without actually closing it, to avoid new tasks from using NostrDB
+        // self.delegate.ndb.markClosed()
         await self.reader.cancelAllTasks()
         await self.pool.cleanQueuedRequestForSessionEnd()
+        await operationBeforeClosingNdb?()
+        self.delegate.ndb.close()
+    }
+    
+    func handleAppForegroundRequest() async {
+        self.delegate.ndb.reopen()
+        // Pinging the network will automatically reconnect any dead websocket connections
+        await self.ping()
     }
     
     func close() async {

--- a/damus/Core/Networking/NostrNetworkManager/NostrNetworkManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/NostrNetworkManager.swift
@@ -61,7 +61,7 @@ class NostrNetworkManager {
     
     func handleAppBackgroundRequest(beforeClosingNdb operationBeforeClosingNdb: (() async -> Void)? = nil) async {
         // Mark NDB as closed without actually closing it, to avoid new tasks from using NostrDB
-        // self.delegate.ndb.markClosed()
+        self.delegate.ndb.markClosed()
         await self.reader.cancelAllTasks()
         await self.pool.cleanQueuedRequestForSessionEnd()
         await operationBeforeClosingNdb?()

--- a/damus/Core/Networking/NostrNetworkManager/ProfilesManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/ProfilesManager.swift
@@ -96,7 +96,7 @@ extension NostrNetworkManager {
             
             if let relevantStreams = streams[metadataEvent.pubkey] {
                 // If we have the user metadata event in ndb, then we should have the profile record as well.
-                guard let profile = ndb.lookup_profile(metadataEvent.pubkey) else { return }
+                guard let profile = ndb.lookup_profile_and_copy(metadataEvent.pubkey) else { return }
                 for relevantStream in relevantStreams.values {
                     relevantStream.continuation.yield(profile)
                 }
@@ -144,7 +144,7 @@ extension NostrNetworkManager {
         
         // MARK: - Helper types
         
-        typealias ProfileStreamItem = NdbTxn<ProfileRecord?>
+        typealias ProfileStreamItem = Profile
         
         struct ProfileStreamInfo {
             let id: UUID = UUID()

--- a/damus/Core/Networking/NostrNetworkManager/UserRelayListManager.swift
+++ b/damus/Core/Networking/NostrNetworkManager/UserRelayListManager.swift
@@ -87,7 +87,7 @@ extension NostrNetworkManager {
         private func getLatestNIP65RelayListEvent() -> NdbNote? {
             guard let latestRelayListEventId = delegate.latestRelayListEventIdHex else { return nil }
             guard let latestRelayListEventId = NoteId(hex: latestRelayListEventId) else { return nil }
-            return delegate.ndb.lookup_note(latestRelayListEventId)?.unsafeUnownedValue?.to_owned()
+            return delegate.ndb.lookup_note_and_copy(latestRelayListEventId)
         }
         
         /// Gets the latest `kind:3` relay list from NostrDB.

--- a/damus/Features/Actions/ActionBar/Views/EventActionBar.swift
+++ b/damus/Features/Actions/ActionBar/Views/EventActionBar.swift
@@ -185,32 +185,42 @@ struct EventActionBar: View {
         let should_hide_repost = hide_items_without_activity && bar.boosts == 0
         let should_hide_reactions = hide_items_without_activity && bar.likes == 0
         let zap_model = self.damus_state.events.get_cache_data(self.event.id).zaps_model
-        let should_hide_zap = hide_items_without_activity && zap_model.zap_total > 0
+        let should_hide_zap = hide_items_without_activity && zap_model.zap_total == 0
         let should_hide_share_button = hide_items_without_activity
+        // Only render the bar if at least one action is visible; avoids empty overlays/dots.
+        let has_any_action = (!should_hide_chat_bubble && damus_state.keypair.privkey != nil)
+            || !should_hide_repost
+            || (show_like && !should_hide_reactions)
+            || (!should_hide_zap && self.lnurl != nil)
+            || !should_hide_share_button
 
-        return HStack(spacing: options.contains(.no_spread) ? 10 : 0) {
-            if damus_state.keypair.privkey != nil && !should_hide_chat_bubble {
-                self.reply_button
-            }
-            
-            if !should_hide_repost {
-                self.space_if_spread
-                self.repost_button
-            }
-            
-            if show_like && !should_hide_reactions {
-                self.space_if_spread
-                self.like_button
-            }
-                
-            if let lnurl = self.lnurl, !should_hide_zap {
-                self.space_if_spread
-                NoteZapButton(damus_state: damus_state, target: ZapTarget.note(id: event.id, author: event.pubkey), lnurl: lnurl, zaps: zap_model)
-            }
-            
-            if !should_hide_share_button {
-                self.space_if_spread
-                self.share_button
+        return Group {
+            if has_any_action {
+                HStack(spacing: options.contains(.no_spread) ? 10 : 0) {
+                    if damus_state.keypair.privkey != nil && !should_hide_chat_bubble {
+                        self.reply_button
+                    }
+                    
+                    if !should_hide_repost {
+                        self.space_if_spread
+                        self.repost_button
+                    }
+                    
+                    if show_like && !should_hide_reactions {
+                        self.space_if_spread
+                        self.like_button
+                    }
+                        
+                    if let lnurl = self.lnurl, !should_hide_zap {
+                        self.space_if_spread
+                        NoteZapButton(damus_state: damus_state, target: ZapTarget.note(id: event.id, author: event.pubkey), lnurl: lnurl, zaps: zap_model)
+                    }
+                    
+                    if !should_hide_share_button {
+                        self.space_if_spread
+                        self.share_button
+                    }
+                }
             }
         }
     }

--- a/damus/Features/Actions/ActionBar/Views/EventActionBar.swift
+++ b/damus/Features/Actions/ActionBar/Views/EventActionBar.swift
@@ -41,9 +41,7 @@ struct EventActionBar: View {
     // Fetching an LNURL is expensive enough that it can cause a hitch. Use a special backgroundable function to fetch the value.
     // Fetch on `.onAppear`
     nonisolated func fetchLNURL() {
-        let lnurl = damus_state.profiles.lookup_with_timestamp(event.pubkey)?.map({ pr in
-            pr?.lnurl
-        }).value
+        let lnurl = damus_state.profiles.lookup_lnurl(event.pubkey)
         DispatchQueue.main.async {
             self.lnurl = lnurl
         }

--- a/damus/Features/Chat/ChatEventView.swift
+++ b/damus/Features/Chat/ChatEventView.swift
@@ -115,9 +115,7 @@ struct ChatEventView: View {
     // MARK: Zapping properties
 
     var lnurl: String? {
-        damus_state.profiles.lookup_with_timestamp(event.pubkey)?.map({ pr in
-            pr?.lnurl
-        }).value
+        damus_state.profiles.lookup_lnurl(event.pubkey)
     }
     var zap_target: ZapTarget {
         ZapTarget.note(id: event.id, author: event.pubkey)

--- a/damus/Features/Events/Components/ReplyDescription.swift
+++ b/damus/Features/Events/Components/ReplyDescription.swift
@@ -38,14 +38,10 @@ func reply_desc(ndb: Ndb, event: NostrEvent, replying_to: NostrEvent?, locale: L
         return NSLocalizedString("Replying to self", bundle: bundle, comment: "Label to indicate that the user is replying to themself.")
     }
 
-    guard let profile_txn = NdbTxn(ndb: ndb) else  {
-        return ""
-    }
-
     let names: [String] = pubkeys.map { pk in
-        let prof = ndb.lookup_profile_with_txn(pk, txn: profile_txn)
+        let profile = ndb.lookup_profile_and_copy(pk)
 
-        return Profile.displayName(profile: prof?.profile, pubkey: pk).username.truncate(maxLength: 50)
+        return Profile.displayName(profile: profile, pubkey: pk).username.truncate(maxLength: 50)
     }
     
     let uniqueNames = NSOrderedSet(array: names).array as! [String]

--- a/damus/Features/Events/Models/NoteContent.swift
+++ b/damus/Features/Events/Models/NoteContent.swift
@@ -72,8 +72,9 @@ func render_immediately_available_note_content(ndb: Ndb, ev: NostrEvent, profile
     }
     
     do {
-        let blocks = try NdbBlockGroup.from(event: ev, using: ndb, and: keypair)
-        return .separated(render_blocks(blocks: blocks, profiles: profiles, can_hide_last_previewable_refs: true))
+        return try NdbBlockGroup.borrowBlockGroup(event: ev, using: ndb, and: keypair, borrow: { blocks in
+            return .separated(render_blocks(blocks: blocks, profiles: profiles, can_hide_last_previewable_refs: true))
+        })
     }
     catch {
         // TODO: Improve error handling in the future, bubbling it up so that the view can decide how display errors. Keep legacy behavior for now.
@@ -327,8 +328,7 @@ func attributed_string_attach_icon(_ astr: inout AttributedString, img: UIImage)
 }
 
 func getDisplayName(pk: Pubkey, profiles: Profiles) -> String {
-    let profile_txn = profiles.lookup(id: pk, txn_name: "getDisplayName")
-    let profile = profile_txn?.unsafeUnownedValue
+    let profile = profiles.lookup(id: pk)
     return Profile.displayName(profile: profile, pubkey: pk).username.truncate(maxLength: 50)
 }
 

--- a/damus/Features/FollowPack/Views/FollowPackPreview.swift
+++ b/damus/Features/FollowPack/Views/FollowPackPreview.swift
@@ -157,8 +157,7 @@ struct FollowPackPreviewBody: View {
                     .onTapGesture {
                         state.nav.push(route: Route.ProfileByKey(pubkey: event.event.pubkey))
                     }
-                let profile_txn = state.profiles.lookup(id: event.event.pubkey)
-                let profile = profile_txn?.unsafeUnownedValue
+                let profile = state.profiles.lookup(id: event.event.pubkey)
                 let displayName = Profile.displayName(profile: profile, pubkey: event.event.pubkey)
                 switch displayName {
                 case .one(let one):

--- a/damus/Features/FollowPack/Views/FollowPackView.swift
+++ b/damus/Features/FollowPack/Views/FollowPackView.swift
@@ -135,8 +135,7 @@ struct FollowPackView: View {
                     .onTapGesture {
                         state.nav.push(route: Route.ProfileByKey(pubkey: event.event.pubkey))
                     }
-                let profile_txn = state.profiles.lookup(id: event.event.pubkey)
-                let profile = profile_txn?.unsafeUnownedValue
+                let profile = state.profiles.lookup(id: event.event.pubkey)
                 let displayName = Profile.displayName(profile: profile, pubkey: event.event.pubkey)
                 switch displayName {
                 case .one(let one):

--- a/damus/Features/Follows/Models/FollowingModel.swift
+++ b/damus/Features/Follows/Models/FollowingModel.swift
@@ -22,11 +22,11 @@ class FollowingModel {
         self.hashtags = hashtags
     }
     
-    func get_filter<Y>(txn: NdbTxn<Y>) -> NostrFilter {
+    func get_filter() -> NostrFilter {
         var f = NostrFilter(kinds: [.metadata])
         f.authors = self.contacts.reduce(into: Array<Pubkey>()) { acc, pk in
             // don't fetch profiles we already have
-            if damus_state.profiles.has_fresh_profile(id: pk, txn: txn) {
+            if damus_state.profiles.has_fresh_profile(id: pk) {
                 return
             }
             acc.append(pk)
@@ -34,8 +34,8 @@ class FollowingModel {
         return f
     }
     
-    func subscribe<Y>(txn: NdbTxn<Y>) {
-        let filter = get_filter(txn: txn)
+    func subscribe() {
+        let filter = get_filter()
         if (filter.authors?.count ?? 0) == 0 {
             needs_sub = false
             return

--- a/damus/Features/Follows/Views/FollowingView.swift
+++ b/damus/Features/Follows/Views/FollowingView.swift
@@ -151,8 +151,7 @@ struct FollowingView: View {
         }
         .tabViewStyle(.page(indexDisplayMode: .never))
         .onAppear {
-            guard let txn = NdbTxn(ndb: self.damus_state.ndb) else { return }
-            following.subscribe(txn: txn)
+            following.subscribe()
         }
         .onDisappear {
             following.unsubscribe()

--- a/damus/Features/Highlight/Models/HighlightEvent.swift
+++ b/damus/Features/Highlight/Models/HighlightEvent.swift
@@ -100,14 +100,10 @@ struct HighlightEvent {
             return NSLocalizedString("Highlighted", bundle: bundle, comment: "Label to indicate that the user is highlighting their own post.")
         }
 
-        guard let profile_txn = NdbTxn(ndb: ndb) else  {
-            return ""
-        }
-
         let names: [String] = pubkeys.map { pk in
-            let prof = ndb.lookup_profile_with_txn(pk, txn: profile_txn)
+            let profile = ndb.lookup_profile_and_copy(pk)
 
-            return Profile.displayName(profile: prof?.profile, pubkey: pk).username.truncate(maxLength: 50)
+            return Profile.displayName(profile: profile, pubkey: pk).username.truncate(maxLength: 50)
         }
 
         let uniqueNames: [String] = Array(Set(names))

--- a/damus/Features/Highlight/Views/HighlightEventRef.swift
+++ b/damus/Features/Highlight/Views/HighlightEventRef.swift
@@ -63,8 +63,7 @@ struct HighlightEventRef: View {
                                 .font(.system(size: 14, weight: .bold))
                                 .lineLimit(1)
 
-                            let profile_txn = damus_state.profiles.lookup(id: longform_event.event.pubkey, txn_name: "highlight-profile")
-                            let profile = profile_txn?.unsafeUnownedValue
+                            let profile = damus_state.profiles.lookup(id: longform_event.event.pubkey)
 
                             if let display_name = profile?.display_name {
                                 Text(display_name)

--- a/damus/Features/Live/LiveStream/Views/Components/LiveStreamProfile.swift
+++ b/damus/Features/Live/LiveStream/Views/Components/LiveStreamProfile.swift
@@ -18,8 +18,7 @@ struct LiveStreamProfile: View {
                 .onTapGesture {
                     state.nav.push(route: Route.ProfileByKey(pubkey: pubkey))
                 }
-            let profile_txn = state.profiles.lookup(id: pubkey)
-            let profile = profile_txn?.unsafeUnownedValue
+            let profile = state.profiles.lookup(id: pubkey)
             let displayName = Profile.displayName(profile: profile, pubkey: pubkey)
             switch displayName {
             case .one(let one):

--- a/damus/Features/NIP05/Models/NIP05DomainEventsModel.swift
+++ b/damus/Features/NIP05/Models/NIP05DomainEventsModel.swift
@@ -47,9 +47,7 @@ class NIP05DomainEventsModel: ObservableObject {
 
         var authors = Set<Pubkey>()
         for pubkey in state.contacts.get_friend_of_friends_list() {
-            let profile_txn = state.profiles.lookup(id: pubkey)
-
-            guard let profile = profile_txn?.unsafeUnownedValue,
+            guard let profile = state.profiles.lookup(id: pubkey),
                   let nip05_str = profile.nip05,
                   let nip05 = NIP05.parse(nip05_str),
                   nip05.host.caseInsensitiveCompare(domain) == .orderedSame else {

--- a/damus/Features/NIP05/Views/NIP05DomainTimelineHeaderView.swift
+++ b/damus/Features/NIP05/Views/NIP05DomainTimelineHeaderView.swift
@@ -82,7 +82,12 @@ struct NIP05DomainTimelineHeaderView: View {
 func friendsOfFriendsString(_ friendsOfFriends: [Pubkey], ndb: Ndb, locale: Locale = Locale.current) -> String {
     let bundle = bundleForLocale(locale: locale)
     let names: [String] = friendsOfFriends.prefix(3).map { pk in
-        let profile = ndb.lookup_profile(pk)?.unsafeUnownedValue?.profile
+        let profile = ndb.lookup_profile(pk, borrow: { pr in
+            switch pr {
+            case .some(let pr): return pr.profile
+            case .none: return nil
+            }
+        })
         return Profile.displayName(profile: profile, pubkey: pk).username.truncate(maxLength: 20)
     }
 

--- a/damus/Features/Onboarding/SuggestedUsersViewModel.swift
+++ b/damus/Features/Onboarding/SuggestedUsersViewModel.swift
@@ -79,8 +79,7 @@ class SuggestedUsersViewModel: ObservableObject {
 
     /// Gets suggested user information from a provided pubkey
     func suggestedUser(pubkey: Pubkey) -> SuggestedUser? {
-        let profile_txn = damus_state.profiles.lookup(id: pubkey)
-        if let profile = profile_txn?.unsafeUnownedValue,
+        if let profile = damus_state.profiles.lookup(id: pubkey),
            let user = SuggestedUser(name: profile.name, about: profile.about, picture: profile.picture, pubkey: pubkey) {
             return user
         }

--- a/damus/Features/Posting/Views/PostView.swift
+++ b/damus/Features/Posting/Views/PostView.swift
@@ -212,8 +212,7 @@ struct PostView: View {
             return .init(string: "")
         }
         
-        let profile_txn = damus_state.profiles.lookup(id: pubkey)
-        let profile = profile_txn?.unsafeUnownedValue
+        let profile = damus_state.profiles.lookup(id: pubkey)
         return user_tag_attr_string(profile: profile, pubkey: pubkey)
     }
     

--- a/damus/Features/Posting/Views/ReplyView.swift
+++ b/damus/Features/Posting/Views/ReplyView.swift
@@ -27,7 +27,7 @@ struct ReplyView: View {
                 let names = references
                     .map { pubkey in
                         let pk = pubkey
-                        let prof = damus.ndb.lookup_profile(pk)?.unsafeUnownedValue?.profile
+                        let prof = damus.profiles.lookup(id: pk)
                         return "@" + Profile.displayName(profile: prof, pubkey: pk).username.truncate(maxLength: 50)
                     }
                     .joined(separator: " ")

--- a/damus/Features/Posting/Views/UserSearch.swift
+++ b/damus/Features/Posting/Views/UserSearch.swift
@@ -17,13 +17,11 @@ struct UserSearch: View {
     @EnvironmentObject var tagModel: TagModel
     
     var users: [Pubkey] {
-        guard let txn = NdbTxn(ndb: damus_state.ndb) else { return [] }
-        return search_profiles(profiles: damus_state.profiles, contacts: damus_state.contacts, search: search, txn: txn)
+        return search_profiles(profiles: damus_state.profiles, contacts: damus_state.contacts, search: search)
     }
     
     func on_user_tapped(pk: Pubkey) {
-        let profile_txn = damus_state.profiles.lookup(id: pk)
-        let profile = profile_txn?.unsafeUnownedValue
+        let profile = damus_state.profiles.lookup(id: pk)
         let user_tag = user_tag_attr_string(profile: profile, pubkey: pk)
 
         appendUserTag(withTag: user_tag)

--- a/damus/Features/Profile/Views/EditMetadataView.swift
+++ b/damus/Features/Profile/Views/EditMetadataView.swift
@@ -33,8 +33,7 @@ struct EditMetadataView: View {
     
     init(damus_state: DamusState) {
         self.damus_state = damus_state
-        let profile_txn = damus_state.profiles.lookup(id: damus_state.pubkey)
-        let data = profile_txn?.unsafeUnownedValue
+        let data = damus_state.profiles.lookup(id: damus_state.pubkey)
 
         _name = State(initialValue: data?.name ?? "")
         _display_name = State(initialValue: data?.display_name ?? "")
@@ -259,8 +258,7 @@ struct EditMetadataView: View {
     }
     
     func didChange() -> Bool {
-        let profile_txn = damus_state.profiles.lookup(id: damus_state.pubkey)
-        let data = profile_txn?.unsafeUnownedValue
+        let data = damus_state.profiles.lookup(id: damus_state.pubkey)
         
         if data?.name ?? "" != name {
             return true

--- a/damus/Features/Profile/Views/EventProfileName.swift
+++ b/damus/Features/Profile/Views/EventProfileName.swift
@@ -25,7 +25,7 @@ struct EventProfileName: View {
         self.damus_state = damus
         self.pubkey = pubkey
         self.size = size
-        let donation = damus.ndb.lookup_profile(pubkey)?.map({ p in p?.profile?.damus_donation }).value
+        let donation = damus.profiles.lookup(id: pubkey)?.damus_donation
         self._donation = State(wrappedValue: donation)
         self.purple_account = nil
         self._profileObserver = StateObject.init(wrappedValue: ProfileObserver(pubkey: pubkey, damusState: damus))
@@ -61,8 +61,7 @@ struct EventProfileName: View {
     }
 
     var body: some View {
-        let profile_txn = damus_state.profiles.lookup(id: pubkey)
-        let profile = profile_txn?.unsafeUnownedValue
+        let profile = damus_state.profiles.lookup(id: pubkey)
         HStack(spacing: 2) {
             switch current_display_name(profile) {
             case .one(let one):
@@ -108,8 +107,7 @@ struct EventProfileName: View {
                 return
             }
 
-            let profile_txn = damus_state.profiles.lookup(id: update.pubkey)
-            guard let profile = profile_txn?.unsafeUnownedValue else { return }
+            guard let profile = damus_state.profiles.lookup(id: update.pubkey) else { return }
 
             let display_name = Profile.displayName(profile: profile, pubkey: pubkey)
             if display_name != self.display_name {

--- a/damus/Features/Profile/Views/ProfileName.swift
+++ b/damus/Features/Profile/Views/ProfileName.swift
@@ -96,8 +96,7 @@ struct ProfileName: View {
     }
     
     var body: some View {
-        let profile_txn = damus_state.profiles.lookup(id: pubkey)
-        let profile = profile_txn?.unsafeUnownedValue
+        let profile = damus_state.profiles.lookup(id: pubkey)
 
         HStack(spacing: 2) {
             Text(verbatim: "\(prefix)\(name_choice(profile: profile))")
@@ -139,8 +138,7 @@ struct ProfileName: View {
 
             switch update {
             case .remote(let pubkey):
-                guard let profile_txn = damus_state.profiles.lookup(id: pubkey),
-                      let prof = profile_txn.unsafeUnownedValue else {
+                guard let prof = damus_state.profiles.lookup(id: pubkey) else {
                     return
                 }
                 handle_profile_update(profile: prof)

--- a/damus/Features/Profile/Views/ProfileNameView.swift
+++ b/damus/Features/Profile/Views/ProfileNameView.swift
@@ -16,8 +16,7 @@ struct ProfileNameView: View {
     var body: some View {
         Group {
             VStack(alignment: .leading) {
-                let profile_txn = self.damus.profiles.lookup(id: pubkey)
-                let profile = profile_txn?.unsafeUnownedValue
+                let profile = self.damus.profiles.lookup(id: pubkey)
 
                 switch Profile.displayName(profile: profile, pubkey: pubkey) {
                 case .one:

--- a/damus/Features/Profile/Views/ProfilePicView.swift
+++ b/damus/Features/Profile/Views/ProfilePicView.swift
@@ -99,7 +99,12 @@ struct ProfilePicView: View {
     }
 
     func get_lnurl() -> String? {
-        return profiles.lookup_with_timestamp(pubkey)?.unsafeUnownedValue?.lnurl
+        return profiles.lookup_with_timestamp(pubkey, borrow: { pr in
+            switch pr {
+            case .some(let pr): return pr.lnurl
+            case .none: return nil
+            }
+        })
     }
     
     var body: some View {
@@ -116,8 +121,7 @@ struct ProfilePicView: View {
                                 self.picture = pic
                             }
                         case .remote(pubkey: let pk):
-                            let profile_txn = profiles.lookup(id: pk)
-                            let profile = profile_txn?.unsafeUnownedValue
+                            let profile = profiles.lookup(id: pk)
                             if let pic = profile?.picture {
                                 self.picture = pic
                             }
@@ -141,7 +145,7 @@ struct ProfilePicView: View {
 }
 
 func get_profile_url(picture: String?, pubkey: Pubkey, profiles: Profiles) -> URL {
-    let pic = picture ?? profiles.lookup(id: pubkey, txn_name: "get_profile_url")?.map({ $0?.picture }).value ?? robohash(pubkey)
+    let pic = picture ?? profiles.lookup(id: pubkey)?.picture ?? robohash(pubkey)
     if let url = URL(string: pic) {
         return url
     }

--- a/damus/Features/Profile/Views/ProfilePictureSelector.swift
+++ b/damus/Features/Profile/Views/ProfilePictureSelector.swift
@@ -52,7 +52,7 @@ struct EditProfilePictureView: View {
         if let profile_url {
             return profile_url
         } else if let state = damus_state,
-                  let picture = state.profiles.lookup(id: pubkey)?.map({ pr in pr?.picture }).value {
+                  let picture = state.profiles.lookup(id: pubkey)?.picture {
             return URL(string: picture)
         } else {
             return profile_url ?? URL(string: robohash(pubkey))

--- a/damus/Features/Purple/Views/DamusPurpleAccountView.swift
+++ b/damus/Features/Purple/Views/DamusPurpleAccountView.swift
@@ -121,8 +121,7 @@ struct DamusPurpleAccountView: View {
     }
     
     func profile_display_name() -> String {
-        let profile_txn: NdbTxn<ProfileRecord?>? = damus_state.profiles.lookup_with_timestamp(account.pubkey)
-        let profile: NdbProfile? = profile_txn?.unsafeUnownedValue?.profile
+        let profile = damus_state.profiles.lookup(id: account.pubkey)
         let display_name = DisplayName(profile: profile, pubkey: account.pubkey).displayName
         return display_name
     }

--- a/damus/Features/Search/Models/SearchHomeModel.swift
+++ b/damus/Features/Search/Models/SearchHomeModel.swift
@@ -110,29 +110,29 @@ class SearchHomeModel: ObservableObject {
     }
 }
 
-func find_profiles_to_fetch<Y>(profiles: Profiles, load: PubkeysToLoad, cache: EventCache, txn: NdbTxn<Y>) -> [Pubkey] {
+func find_profiles_to_fetch(profiles: Profiles, load: PubkeysToLoad, cache: EventCache) -> [Pubkey] {
     switch load {
     case .from_events(let events):
-        return find_profiles_to_fetch_from_events(profiles: profiles, events: events, cache: cache, txn: txn)
+        return find_profiles_to_fetch_from_events(profiles: profiles, events: events, cache: cache)
     case .from_keys(let pks):
-        return find_profiles_to_fetch_from_keys(profiles: profiles, pks: pks, txn: txn)
+        return find_profiles_to_fetch_from_keys(profiles: profiles, pks: pks)
     }
 }
 
-func find_profiles_to_fetch_from_keys<Y>(profiles: Profiles, pks: [Pubkey], txn: NdbTxn<Y>) -> [Pubkey] {
-    Array(Set(pks.filter { pk in !profiles.has_fresh_profile(id: pk, txn: txn) }))
+func find_profiles_to_fetch_from_keys(profiles: Profiles, pks: [Pubkey]) -> [Pubkey] {
+    Array(Set(pks.filter { pk in !profiles.has_fresh_profile(id: pk) }))
 }
 
-func find_profiles_to_fetch_from_events<Y>(profiles: Profiles, events: [NostrEvent], cache: EventCache, txn: NdbTxn<Y>) -> [Pubkey] {
+func find_profiles_to_fetch_from_events(profiles: Profiles, events: [NostrEvent], cache: EventCache) -> [Pubkey] {
     var pubkeys = Set<Pubkey>()
 
     for ev in events {
         // lookup profiles from boosted events
-        if ev.known_kind == .boost, let bev = ev.get_inner_event(cache: cache), !profiles.has_fresh_profile(id: bev.pubkey, txn: txn) {
+        if ev.known_kind == .boost, let bev = ev.get_inner_event(cache: cache), !profiles.has_fresh_profile(id: bev.pubkey) {
             pubkeys.insert(bev.pubkey)
         }
         
-        if !profiles.has_fresh_profile(id: ev.pubkey, txn: txn) {
+        if !profiles.has_fresh_profile(id: ev.pubkey) {
             pubkeys.insert(ev.pubkey)
         }
     }

--- a/damus/Features/Settings/Models/UserSettingsStore.swift
+++ b/damus/Features/Settings/Models/UserSettingsStore.swift
@@ -191,8 +191,12 @@ class UserSettingsStore: ObservableObject {
     var truncate_timeline_text: Bool
     
     /// Nozaps mode gimps note zapping to fit into apple's content-tipping guidelines. It can not be configurable to end-users on the app store
+    ///
+    /// Update 2025-05-12: This can be re-enabled 🥳. See https://github.com/damus-io/damus/issues/3016
     // @Setting(key: "nozaps", default_value: true)
-    var nozaps: Bool { true }
+    var nozaps: Bool {
+        return false
+    }
     
     @Setting(key: "truncate_mention_text", default_value: true)
     var truncate_mention_text: Bool

--- a/damus/Features/Timeline/Models/HomeModel.swift
+++ b/damus/Features/Timeline/Models/HomeModel.swift
@@ -120,7 +120,7 @@ class HomeModel: ContactsDelegate, ObservableObject {
         damus_state.contacts.delegate = self
         guard let latest_contact_event_id_hex = damus_state.settings.latest_contact_event_id_hex else { return }
         guard let latest_contact_event_id = NoteId(hex: latest_contact_event_id_hex) else { return }
-        guard let latest_contact_event: NdbNote = damus_state.ndb.lookup_note( latest_contact_event_id)?.unsafeUnownedValue?.to_owned() else { return }
+        guard let latest_contact_event: NdbNote = damus_state.ndb.lookup_note_and_copy(latest_contact_event_id) else { return }
         process_contact_event(state: damus_state, ev: latest_contact_event)
     }
     

--- a/damus/Features/Timeline/Views/PostingTimelineSwitcherView.swift
+++ b/damus/Features/Timeline/Views/PostingTimelineSwitcherView.swift
@@ -36,10 +36,9 @@ struct PostingTimelineSwitcherView: View {
                 }
             }
         } label: {
-            Image(systemName: "square.stack")
-                .foregroundColor(DamusColors.purple)
-                .frame(height: 35)
+            Color.clear
         }
+        .frame(width: 50, height: 35)
         .menuOrder(.fixed)
         .accessibilityLabel(NSLocalizedString("Timeline switcher, select \(TimelineSource.follows.description) or \(TimelineSource.favorites.description)", comment: "Accessibility label for the timeline switcher button at the topbar"))
     }
@@ -68,10 +67,13 @@ struct PostingTimelineSwitcherView: View {
 
 struct PostingTimelineSwitcherView_Previews: PreviewProvider {
     static var previews: some View {
-        PostingTimelineSwitcherView(
-            damusState: test_damus_state,
-            timelineSource: .constant(.follows)
-        )
+        VStack {
+            PostingTimelineSwitcherView(
+                damusState: test_damus_state,
+                timelineSource: .constant(.follows)
+            )
+            Spacer()
+        }
     }
 }
 

--- a/damus/Features/Timeline/Views/PostingTimelineView.swift
+++ b/damus/Features/Timeline/Views/PostingTimelineView.swift
@@ -64,7 +64,7 @@ struct PostingTimelineView: View {
                 HStack {}
                 .frame(height: getSafeAreaTop())
 
-                HStack(alignment: .top) {
+                HStack(alignment: .center) {
                     TopbarSideMenuButton(damus_state: damus_state, isSideBarOpened: $isSideBarOpened)
 
                     Spacer()
@@ -77,8 +77,12 @@ struct PostingTimelineView: View {
                                 timelineSource: $timeline_source
                             )
                             if #available(iOS 17.0, *) {
+                                Image(systemName: "square.stack")
+                                    .foregroundColor(DamusColors.purple)
+                                    .overlay(
                                 switchView
                                     .popoverTip(PostingTimelineSwitcherView.TimelineSwitcherTip.shared)
+                                    )
                             } else {
                                 switchView
                             }

--- a/damus/Features/Timeline/Views/SideMenuView.swift
+++ b/damus/Features/Timeline/Views/SideMenuView.swift
@@ -136,8 +136,7 @@ struct SideMenuView: View {
         var display_name: String? = nil
 
         do {
-            let profile_txn = damus_state.ndb.lookup_profile(damus_state.pubkey, txn_name: "top_profile")
-            let profile = profile_txn?.unsafeUnownedValue?.profile
+            let profile = damus_state.profiles.lookup(id: damus_state.pubkey)
             name = profile?.name
             display_name = profile?.display_name
         }

--- a/damus/Features/Wallet/Views/NWCSettings.swift
+++ b/damus/Features/Wallet/Views/NWCSettings.swift
@@ -244,8 +244,7 @@ struct NWCSettings: View {
             }
         }
         .onChange(of: model.settings.donation_percent) { p in
-            let profile_txn = damus_state.profiles.lookup(id: damus_state.pubkey)
-            guard let profile = profile_txn?.unsafeUnownedValue else {
+            guard let profile = damus_state.profiles.lookup(id: damus_state.pubkey) else {
                 return
             }
             
@@ -254,10 +253,9 @@ struct NWCSettings: View {
             notify(.profile_updated(.manual(pubkey: self.damus_state.pubkey, profile: prof)))
         }
         .onDisappear {
-            let profile_txn = damus_state.profiles.lookup(id: damus_state.pubkey)
             
             guard let keypair = damus_state.keypair.to_full(),
-                  let profile = profile_txn?.unsafeUnownedValue,
+                  let profile = damus_state.profiles.lookup(id: damus_state.pubkey),
                   model.initial_percent != profile.damus_donation
             else {
                 return

--- a/damus/Features/Wallet/Views/TransactionsView.swift
+++ b/damus/Features/Wallet/Views/TransactionsView.swift
@@ -104,8 +104,7 @@ struct TransactionView: View {
             return NSLocalizedString("Unknown", comment: "A name label for an unknown user")
         }
 
-        let profile_txn = damus_state.profiles.lookup(id: pubkey, txn_name: "txview-profile")
-        let profile = profile_txn?.unsafeUnownedValue
+        let profile = damus_state.profiles.lookup(id: pubkey)
 
         return Profile.displayName(profile: profile, pubkey: pubkey).displayName
     }

--- a/damus/Features/Zaps/Views/ProfileZapLinkView.swift
+++ b/damus/Features/Zaps/Views/ProfileZapLinkView.swift
@@ -33,21 +33,26 @@ struct ProfileZapLinkView<Content: View>: View {
         self.label = label
         self.action = action
         
-        let profile_txn = damus_state.profiles.lookup_with_timestamp(pubkey)
-        let record = profile_txn?.unsafeUnownedValue
-        self.reactions_enabled = record?.profile?.reactions ?? true
-        self.lud16 = record?.profile?.lud06?.trimmingCharacters(in: .whitespaces)
-        self.lnurl = record?.lnurl?.trimmingCharacters(in: .whitespaces)
+        let profile = damus_state.profiles.lookup(id: pubkey)
+        let lnurl = damus_state.profiles.lookup_with_timestamp(pubkey, borrow: { pr -> String? in
+            switch pr {
+            case .some(let pr): return pr.lnurl
+            case .none: return nil
+            }
+        })
+        self.reactions_enabled = profile?.reactions ?? true
+        self.lud16 = profile?.lud06?.trimmingCharacters(in: .whitespaces)
+        self.lnurl = lnurl?.trimmingCharacters(in: .whitespaces)
     }
     
-    init(unownedProfileRecord: ProfileRecord?, profileModel: ProfileModel, action: ActionFunction? = nil, @ViewBuilder label: @escaping ContentViewFunction) {
+    init(profile: Profile?, lnurl: String?, profileModel: ProfileModel, action: ActionFunction? = nil, @ViewBuilder label: @escaping ContentViewFunction) {
         self.pubkey = profileModel.pubkey
         self.label = label
         self.action = action
         
-        self.reactions_enabled = unownedProfileRecord?.profile?.reactions ?? true
-        self.lud16 = unownedProfileRecord?.profile?.lud16?.trimmingCharacters(in: .whitespaces)
-        self.lnurl = unownedProfileRecord?.lnurl?.trimmingCharacters(in: .whitespaces)
+        self.reactions_enabled = profile?.reactions ?? true
+        self.lud16 = profile?.lud16?.trimmingCharacters(in: .whitespaces)
+        self.lnurl = lnurl?.trimmingCharacters(in: .whitespaces)
     }
     
     var body: some View {

--- a/damus/Features/Zaps/Views/ZapTypePicker.swift
+++ b/damus/Features/Zaps/Views/ZapTypePicker.swift
@@ -97,8 +97,7 @@ func zap_type_desc(type: ZapType, profiles: Profiles, pubkey: Pubkey) -> String 
     case .anon:
         return NSLocalizedString("No one will see that you zapped", comment: "Description of anonymous zap type where the zap is sent anonymously and does not identify the user who sent it.")
     case .priv:
-        let prof_txn = profiles.lookup(id: pubkey)
-        let prof = prof_txn?.unsafeUnownedValue
+        let prof = profiles.lookup(id: pubkey)
         let name = Profile.displayName(profile: prof, pubkey: pubkey).username.truncate(maxLength: 50)
         return String.localizedStringWithFormat(NSLocalizedString("private_zap_description", value: "Only '%@' will see that you zapped them", comment: "Description of private zap type where the zap is sent privately and does not identify the user to the public."), name)
     case .non_zap:

--- a/damus/Shared/Components/NIP05Badge.swift
+++ b/damus/Shared/Components/NIP05Badge.swift
@@ -60,7 +60,7 @@ struct NIP05Badge: View {
     }
 
     var username_matches_nip05: Bool {
-        guard let name = damus_state.profiles.lookup(id: pubkey)?.map({ p in p?.name }).value
+        guard let name = damus_state.profiles.lookup(id: pubkey)?.name
         else {
             return false
         }

--- a/damus/Shared/Components/QRCodeView.swift
+++ b/damus/Shared/Components/QRCodeView.swift
@@ -73,8 +73,7 @@ struct QRCodeView: View {
     
     var QRView: some View {
         VStack(alignment: .center) {
-            let profile_txn = damus_state.profiles.lookup(id: pubkey, txn_name: "qrview-profile")
-            let profile = profile_txn?.unsafeUnownedValue
+            let profile = damus_state.profiles.lookup(id: pubkey)
 
             ProfilePicView(pubkey: pubkey, size: 90.0, highlight: .custom(DamusColors.white, 3.0), profiles: damus_state.profiles, disable_animation: damus_state.settings.disable_animation, damusState: damus_state)
                     .padding(.top, 20)

--- a/damus/Shared/Media/Images/BannerImageView.swift
+++ b/damus/Shared/Media/Images/BannerImageView.swift
@@ -104,13 +104,12 @@ struct BannerImageView: View {
         InnerBannerImageView(disable_animation: disable_animation, url: get_banner_url(banner: banner, pubkey: pubkey, profiles: profiles))
             .onReceive(handle_notify(.profile_updated)) { updated in
                 guard updated.pubkey == self.pubkey,
-                      let profile_txn = profiles.lookup(id: updated.pubkey)
+                      let profile = profiles.lookup(id: updated.pubkey)
                 else {
                     return
                 }
 
-                let profile = profile_txn.unsafeUnownedValue
-                if let bannerImage = profile?.banner, bannerImage != self.banner {
+                if let bannerImage = profile.banner, bannerImage != self.banner {
                     self.banner = bannerImage
                 }
             }
@@ -118,7 +117,7 @@ struct BannerImageView: View {
 }
 
 func get_banner_url(banner: String?, pubkey: Pubkey, profiles: Profiles) -> URL? {
-    let bannerUrlString = banner ?? profiles.lookup(id: pubkey)?.map({ p in p?.banner }).value ?? ""
+    let bannerUrlString = banner ?? profiles.lookup(id: pubkey)?.banner ?? ""
     if let url = URL(string: bannerUrlString) {
         return url
     }

--- a/damus/Shared/Utilities/DisplayName.swift
+++ b/damus/Shared/Utilities/DisplayName.swift
@@ -56,33 +56,53 @@ enum DisplayName: Equatable {
 }
 
 
+/// Parses profile name fields into a DisplayName, with graceful fallback to abbreviated bech32 pubkey.
+///
+/// Resolution order:
+/// 1. If both `name` and `display_name` exist and differ → `.both(username:displayName:)`
+/// 2. If only one of `name` or `display_name` exists → `.one(thatValue)`
+/// 3. If neither exists (profile not found or empty) → `.one(abbreviated_npub)`
+///
+/// The abbreviated npub format (e.g., "1abc1234:xyz89012") is used when no profile metadata
+/// is available. This commonly occurs in push notifications when the sender's profile
+/// hasn't been fetched from relays yet.
 func parse_display_name(name: String?, display_name: String?, pubkey: Pubkey) -> DisplayName {
     if pubkey == ANON_PUBKEY {
         return .one(NSLocalizedString("Anonymous", comment: "Placeholder display name of anonymous user."))
     }
 
+    // Early return: no profile data available, fall back to abbreviated bech32
     if name == nil && display_name == nil {
         return .one(abbrev_bech32_pubkey(pubkey: pubkey))
     }
 
+    // Treat empty strings as nil for cleaner logic
     let name = name?.isEmpty == false ? name : nil
     let disp_name = display_name?.isEmpty == false ? display_name : nil
-    
+
     if let name, let disp_name, name != disp_name {
         return .both(username: name, displayName: disp_name)
     }
-    
+
     if let one = name ?? disp_name {
         return .one(one)
     }
-    
+
+    // Final fallback: abbreviated bech32 pubkey
     return .one(abbrev_bech32_pubkey(pubkey: pubkey))
 }
 
+/// Creates an abbreviated display string from a bech32 pubkey.
+/// Strips the "npub" prefix and abbreviates to "prefix:suffix" format.
+/// Example: npub1abc123...xyz789 → "1abc1234:xyz78912"
 func abbrev_bech32_pubkey(pubkey: Pubkey) -> String {
+    // Drop the "npub" prefix (4 chars) before abbreviating
     return abbrev_identifier(String(pubkey.npub.dropFirst(4)))
 }
 
+/// Abbreviates a string to "prefix:suffix" format for compact display.
+/// Default shows 8 characters from each end.
+/// Example: "abcdefghijklmnopqrstuvwxyz" → "abcdefgh:stuvwxyz"
 func abbrev_identifier(_ pubkey: String, amount: Int = 8) -> String {
     return pubkey.prefix(amount) + ":" + pubkey.suffix(amount)
 }

--- a/damus/Shared/Utilities/EventCache.swift
+++ b/damus/Shared/Utilities/EventCache.swift
@@ -222,7 +222,7 @@ class EventCache {
             return ev
         }
 
-        if let ev = self.ndb.lookup_note(evid)?.unsafeUnownedValue?.to_owned() {
+        if let ev = self.ndb.lookup_note_and_copy(evid) {
             events[ev.id] = ev
             return ev
         }

--- a/damusTests/NostrNetworkManagerTests/NostrNetworkManagerTests.swift
+++ b/damusTests/NostrNetworkManagerTests/NostrNetworkManagerTests.swift
@@ -137,11 +137,9 @@ class NostrNetworkManagerTests: XCTestCase {
                     switch item {
                     case .event(let noteKey):
                         // Lookup the note to verify it exists
-                        if let txn = NdbTxn(ndb: ndb) {
-                            if let note = ndb.lookup_note_by_key_with_txn(noteKey, txn: txn) {
-                                count += 1
-                                receivedIds.insert(note.id)
-                            }
+                        if let note = ndb.lookup_note_by_key_and_copy(noteKey) {
+                            count += 1
+                            receivedIds.insert(note.id)
                         }
                         if count >= expectedCount {
                             atLeastXNotes.fulfill()

--- a/damusTests/NoteContentViewTests.swift
+++ b/damusTests/NoteContentViewTests.swift
@@ -347,15 +347,17 @@ class NoteContentViewTests: XCTestCase {
     func testDirectBlockParsing() {
         let kp = test_keypair_full
         let dm: NdbNote = NIP04.create_dm("Test", to_pk: kp.pubkey, tags: [], keypair: kp.to_keypair())!
-        let blocks = try! NdbBlockGroup.from(event: dm, using: test_damus_state.ndb, and: kp.to_keypair())
-        let blockCount1 = try? blocks.withList({ $0.count })
-        XCTAssertEqual(blockCount1, 1)
+        try! NdbBlockGroup.borrowBlockGroup(event: dm, using: test_damus_state.ndb, and: kp.to_keypair(), borrow: { blocks in
+            let blockCount = blocks.withList({ $0.count })
+            XCTAssertEqual(blockCount, 1)
+        })
         
         let post = NostrPost(content: "Test", kind: .text)
         let event = post.to_event(keypair: kp)!
-        let blocks2 = try! NdbBlockGroup.from(event: event, using: test_damus_state.ndb, and: kp.to_keypair())
-        let blockCount2 = try? blocks2.withList({ $0.count })
-        XCTAssertEqual(blockCount2, 1)
+        try! NdbBlockGroup.borrowBlockGroup(event: event, using: test_damus_state.ndb, and: kp.to_keypair(), borrow: { blocks in
+            let blockCount = blocks.withList({ $0.count })
+            XCTAssertEqual(blockCount, 1)
+        })
     }
     
     func testMentionStr_Pubkey_ContainsAbbreviated() throws {

--- a/nostrdb/Ndb+.swift
+++ b/nostrdb/Ndb+.swift
@@ -29,8 +29,8 @@ extension Ndb {
     }
     
     /// Determines if a given note was seen on any of the listed relay URLs
-    func was(noteKey: NoteKey, seenOnAnyOf relayUrls: [RelayURL], txn: SafeNdbTxn<()>? = nil) throws -> Bool {
-        return try self.was(noteKey: noteKey, seenOnAnyOf: relayUrls.map({ $0.absoluteString }), txn: txn)
+    func was(noteKey: NoteKey, seenOnAnyOf relayUrls: [RelayURL]) throws -> Bool {
+        return try self.was(noteKey: noteKey, seenOnAnyOf: relayUrls.map({ $0.absoluteString }))
     }
     
     func processEvent(_ str: String, originRelayURL: RelayURL? = nil) -> Bool {

--- a/nostrdb/Ndb+.swift
+++ b/nostrdb/Ndb+.swift
@@ -18,12 +18,12 @@ extension Ndb {
     ///   - maxSimultaneousResults: Maximum number of initial results to return
     /// - Returns: AsyncStream of StreamItem events
     /// - Throws: NdbStreamError if subscription fails
-    func subscribe(filters: [NostrFilter], maxSimultaneousResults: Int = 1000) throws(NdbStreamError) -> AsyncStream<StreamItem> {
+    func subscribe(filters: [NostrFilter], maxSimultaneousResults: Int = 1000) throws -> AsyncStream<StreamItem> {
         let ndbFilters: [NdbFilter]
         do {
             ndbFilters = try filters.toNdbFilters()
         } catch {
-            throw .cannotConvertFilter(error)
+            throw NdbStreamError.cannotConvertFilter(error)
         }
         return try self.subscribe(filters: ndbFilters, maxSimultaneousResults: maxSimultaneousResults)
     }

--- a/nostrdb/Ndb.swift
+++ b/nostrdb/Ndb.swift
@@ -207,6 +207,12 @@ class Ndb {
         self.callbackHandler = Ndb.CallbackHandler()
     }
     
+    /// Mark NostrDB as "closed" without actually closing it.
+    /// Useful when shutting down tasks that use NostrDB while avoiding new tasks from using it.
+    func markClosed() {
+        self.closed = true
+    }
+    
     func close() {
         guard !self.is_closed else { return }
         self.closed = true

--- a/nostrdb/NdbTxn.swift
+++ b/nostrdb/NdbTxn.swift
@@ -78,7 +78,7 @@ class NdbTxn<T>: RawNdbTxnAccessible {
 
     /// Only access temporarily! Do not store database references for longterm use. If it's a primitive type you
     /// can retrieve this value with `.value`
-    var unsafeUnownedValue: T {
+    internal var unsafeUnownedValue: T { 
         precondition(!moved)
         return val
     }


### PR DESCRIPTION
## Summary\n- ensure notification PFPs are downloaded to disk with stable filenames and correct image type detection\n- validate/delete corrupt cached files and clean up old ones in a dedicated app-group subdir\n- document/log the expected bech32 fallback when a sender profile isn"t in the shared DB\n\nFixes #3152