### PR TITLE
Fix stretched/cut-off images in longform notes

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -627,6 +627,7 @@
 		7C60CAEF298471A1009C80D6 /* CoreSVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C60CAEE298471A1009C80D6 /* CoreSVG.swift */; };
 		7C902AE32981D55B002AB16E /* ZoomableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */; };
 		7C95CAEE299DCEF1009DCB67 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
+		K9G5YXAZ4Y19GSLH8TWS8CO1 /* KingfisherImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */; };
 		7CFF6317299FEFE5005D382A /* SelectableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFF6316299FEFE5005D382A /* SelectableText.swift */; };
 		82D6FA9A2CD9820500C925F4 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D6FA992CD9820500C925F4 /* ShareViewController.swift */; };
 		82D6FAA12CD9820500C925F4 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 82D6FA972CD9820500C925F4 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -745,6 +746,7 @@
 		82D6FB2F2CD99F7900C925F4 /* BlurHashDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C198DEE29F88C6B004C165C /* BlurHashDecode.swift */; };
 		82D6FB302CD99F7900C925F4 /* PostBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE4F0F329D779B5005914DB /* PostBox.swift */; };
 		82D6FB312CD99F7900C925F4 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
+		FQ9UEENWE218BBQDVQXU3RA9 /* KingfisherImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */; };
 		82D6FB322CD99F7900C925F4 /* FillAndStroke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7D09752A0AF19E00943473 /* FillAndStroke.swift */; };
 		82D6FB332CD99F7900C925F4 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72E12772BEED22400F4F781 /* Array.swift */; };
 		82D6FB342CD99F7900C925F4 /* VectorMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78DB85A2C20FE4F00F0AB12 /* VectorMath.swift */; };
@@ -1360,6 +1362,7 @@
 		D73E5E632C6A97F4007EB227 /* BlurHashDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C198DEE29F88C6B004C165C /* BlurHashDecode.swift */; };
 		D73E5E642C6A97F4007EB227 /* PostBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE4F0F329D779B5005914DB /* PostBox.swift */; };
 		D73E5E652C6A97F4007EB227 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
+		3RRUR7Z6M0UHAOFZTGU9GRU0 /* KingfisherImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */; };
 		D73E5E662C6A97F4007EB227 /* FillAndStroke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7D09752A0AF19E00943473 /* FillAndStroke.swift */; };
 		D73E5E672C6A97F4007EB227 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72E12772BEED22400F4F781 /* Array.swift */; };
 		D73E5E682C6A97F4007EB227 /* VectorMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78DB85A2C20FE4F00F0AB12 /* VectorMath.swift */; };
@@ -2684,6 +2687,7 @@
 		7C60CAEE298471A1009C80D6 /* CoreSVG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSVG.swift; sourceTree = "<group>"; };
 		7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableScrollView.swift; sourceTree = "<group>"; };
 		7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KFOptionSetter+.swift"; sourceTree = "<group>"; };
+		BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KingfisherImageProvider.swift; sourceTree = "<group>"; };
 		7CFF6316299FEFE5005D382A /* SelectableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableText.swift; sourceTree = "<group>"; };
 		82D6FA972CD9820500C925F4 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		82D6FA992CD9820500C925F4 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
@@ -5100,6 +5104,7 @@
 			isa = PBXGroup;
 			children = (
 				7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */,
+				BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */,
 				4C7D09752A0AF19E00943473 /* FillAndStroke.swift */,
 				D72E12772BEED22400F4F781 /* Array.swift */,
 				D78DB85A2C20FE4F00F0AB12 /* VectorMath.swift */,
@@ -5948,6 +5953,7 @@
 				4C0A3F93280F66F5000448DE /* ReplyMap.swift in Sources */,
 				4C2B7BF22A71B6540049DEE7 /* Id.swift in Sources */,
 				7C95CAEE299DCEF1009DCB67 /* KFOptionSetter+.swift in Sources */,
+				K9G5YXAZ4Y19GSLH8TWS8CO1 /* KingfisherImageProvider.swift in Sources */,
 				4C7D09722A0AEF5E00943473 /* DamusGradient.swift in Sources */,
 				4C463CBF2B960B96008A8C36 /* PurpleBackdrop.swift in Sources */,
 				5C8F97502EBD704A009399B1 /* LabsToggleView.swift in Sources */,
@@ -6506,6 +6512,7 @@
 				82D6FB302CD99F7900C925F4 /* PostBox.swift in Sources */,
 				5C8F970B2EB45E8C009399B1 /* LiveChatModel.swift in Sources */,
 				82D6FB312CD99F7900C925F4 /* KFOptionSetter+.swift in Sources */,
+				FQ9UEENWE218BBQDVQXU3RA9 /* KingfisherImageProvider.swift in Sources */,
 				5C8F972F2EB46116009399B1 /* LiveStreamStatus.swift in Sources */,
 				D73BDB162D71216500D69970 /* UserRelayListManager.swift in Sources */,
 				82D6FB322CD99F7900C925F4 /* FillAndStroke.swift in Sources */,
@@ -6986,6 +6993,7 @@
 				D76BE18E2E0CF3DA004AD0C6 /* Interests.swift in Sources */,
 				D73E5E642C6A97F4007EB227 /* PostBox.swift in Sources */,
 				D73E5E652C6A97F4007EB227 /* KFOptionSetter+.swift in Sources */,
+				3RRUR7Z6M0UHAOFZTGU9GRU0 /* KingfisherImageProvider.swift in Sources */,
 				D73E5E662C6A97F4007EB227 /* FillAndStroke.swift in Sources */,
 				D73E5E672C6A97F4007EB227 /* Array.swift in Sources */,
 				D73E5E682C6A97F4007EB227 /* VectorMath.swift in Sources */,

--- a/damus/Features/Events/NoteContentView.swift
+++ b/damus/Features/Events/NoteContentView.swift
@@ -361,7 +361,10 @@ struct NoteContentView: View {
         Group {
             switch self.note_artifacts {
             case .longform(let md):
+                // Note: Do NOT apply .fixedSize to longform content - it prevents async images from expanding
                 Markdown(md.markdown)
+                    .markdownImageProvider(.kingfisher(disable_animation: damus_state.settings.disable_animation))
+                    .markdownInlineImageProvider(.kingfisher)
                     .padding([.leading, .trailing, .top])
             case .separated(let separated):
                 if #available(iOS 17.4, macOS 14.4, *) {
@@ -369,12 +372,13 @@ struct NoteContentView: View {
 #if !targetEnvironment(macCatalyst)
                         .translationPresentation(isPresented: $isAppleTranslationPopoverPresented, text: event.get_content(damus_state.keypair))
 #endif
+                        .fixedSize(horizontal: false, vertical: true)
                 } else {
                     MainContent(artifacts: separated)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
-        .fixedSize(horizontal: false, vertical: true)
     }
 
     var normalizedHighlightTerms: [String] {

--- a/damus/Features/Longform/Views/LongformView.swift
+++ b/damus/Features/Longform/Views/LongformView.swift
@@ -11,13 +11,13 @@ struct LongformView: View {
     let state: DamusState
     let event: LongformEvent
     @ObservedObject var artifacts: NoteArtifactsModel
-    
+
     init(state: DamusState, event: LongformEvent, artifacts: NoteArtifactsModel? = nil) {
         self.state = state
         self.event = event
         self._artifacts = ObservedObject(wrappedValue: artifacts ?? state.events.get_cache_data(event.event.id).artifacts_model)
     }
-    
+
     var options: EventViewOptions {
         return [.wide, .no_mentions, .no_replying_to]
     }

--- a/damus/Shared/Extensions/KingfisherImageProvider.swift
+++ b/damus/Shared/Extensions/KingfisherImageProvider.swift
@@ -1,0 +1,98 @@
+//
+//  KingfisherImageProvider.swift
+//  damus
+//
+//  Created by alltheseas on 2026-01-03.
+//
+
+import SwiftUI
+import Kingfisher
+import MarkdownUI
+
+/// A custom image provider for MarkdownUI that uses Kingfisher for image loading.
+/// This provides proper aspect ratio handling and caching for images in longform markdown content.
+struct KingfisherImageProvider: ImageProvider {
+    let disable_animation: Bool
+
+    init(disable_animation: Bool = false) {
+        self.disable_animation = disable_animation
+    }
+
+    func makeImage(url: URL?) -> some View {
+        KingfisherMarkdownImage(url: url, disable_animation: disable_animation)
+    }
+}
+
+extension ImageProvider where Self == KingfisherImageProvider {
+    /// A Kingfisher-based image provider for loading images with proper caching and aspect ratio handling.
+    static var kingfisher: Self { .init() }
+
+    /// A Kingfisher-based image provider with animation disabled.
+    static func kingfisher(disable_animation: Bool) -> Self {
+        .init(disable_animation: disable_animation)
+    }
+}
+
+// MARK: - InlineImageProvider (for images mixed with text)
+
+/// A custom inline image provider for MarkdownUI that uses Kingfisher for loading inline images.
+/// This handles images that appear within text content (not standalone image paragraphs).
+struct KingfisherInlineImageProvider: InlineImageProvider {
+    func image(with url: URL, label: String) async throws -> Image {
+        return try await withCheckedThrowingContinuation { continuation in
+            KingfisherManager.shared.retrieveImage(with: url) { result in
+                switch result {
+                case .success(let imageResult):
+                    continuation.resume(returning: Image(uiImage: imageResult.image))
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+extension InlineImageProvider where Self == KingfisherInlineImageProvider {
+    /// A Kingfisher-based inline image provider for loading images within text.
+    static var kingfisher: Self { .init() }
+}
+
+// MARK: - ImageProvider View (for standalone image paragraphs)
+
+/// Internal view that handles the actual Kingfisher image loading for markdown content.
+/// Uses state to track loaded image dimensions for proper aspect ratio sizing.
+private struct KingfisherMarkdownImage: View {
+    let url: URL?
+    let disable_animation: Bool
+    @State private var imageSize: CGSize?
+
+    /// Returns a valid aspect ratio, guarding against zero/invalid dimensions.
+    private var safeAspectRatio: CGSize {
+        guard let size = imageSize, size.width > 0, size.height > 0 else {
+            return CGSize(width: 1, height: 1)
+        }
+        return size
+    }
+
+    var body: some View {
+        if let url {
+            KFAnimatedImage(url)
+                .callbackQueue(.dispatch(.global(qos: .background)))
+                .backgroundDecode(true)
+                .imageContext(.note, disable_animation: disable_animation)
+                .image_fade(duration: 0.25)
+                .cancelOnDisappear(true)
+                .configure { view in
+                    view.framePreloadCount = 3
+                }
+                .observe_image_size { size in
+                    imageSize = size
+                }
+                .aspectRatio(safeAspectRatio, contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .kfClickable()
+        } else {
+            EmptyView()
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Images in longform markdown content were being cut off because MarkdownUI parsed them as inline elements within text paragraphs. This happened when markdown had single `\n` after images instead of `\n\n` (paragraph break).

This PR adds pre-processing to ensure standalone images are parsed as block-level elements, plus a custom Kingfisher-based image provider for proper aspect ratio handling.

**Key changes:**
- Add `ensureBlockLevelImages()` pre-processing to add paragraph breaks around markdown images
- Create `KingfisherImageProvider` for MarkdownUI with proper aspect ratio and caching
- Move `.fixedSize` modifier to only apply to non-longform content

**Safety measures (to avoid breaking markdown structure):**
- Skip images inside lists, blockquotes, tables, and all code block variants
- Use `Range<String.Index>` consistently for correct non-ASCII handling

Closes: https://github.com/damus-io/damus/issues/1692

## Checklist

### Standard PR Checklist

- [x] I have read (or I am familiar with) the [Contribution Guidelines](../docs/CONTRIBUTING.md)
- [x] I have tested the changes in this PR
- [x] I have profiled the changes to ensure there are no performance regressions, or I do not need to profile the changes.
    - If not needed, provide reason: Pre-processing runs once per longform note load; regex operations are lightweight
- [x] I have opened or referred to an existing github issue related to this change.
- [x] My PR is either small, or I have split it into smaller logical commits that are easier to review
- [x] I have added the signoff line to all my commits. See [Signing off your work](../docs/CONTRIBUTING.md#sign-your-work---the-developers-certificate-of-origin)
- [x] I have added appropriate changelog entries for the changes in this PR. See [Adding changelog entries](../docs/CONTRIBUTING.md#add-changelog-changed-changelog-fixed-etc)
- [x] I have added appropriate `Closes:` or `Fixes:` tags in the commit messages wherever applicable, or made sure those are not needed.

## Test report

**Device:** iPhone 17 Pro Simulator

**iOS:** 26.2

**Damus:** c4e347c0

**Setup:** Opened longform notes containing images via naddr links

**Steps:**
1. Launch Damus on simulator
2. Navigate to a longform note with images
3. Verify images display with proper aspect ratio and are not cut off

**Results:**
- [x] PASS

## Other notes

**Known limitations** (images remain inline but are handled by InlineImageProvider fallback):
- Multi-line list items with images on continuation lines
- Reference-style images: `![alt][id]`
- HTML `<img>` tags

These edge cases preserve markdown structure rather than risk breaking lists/blockquotes.

Signed-off-by: alltheseas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sepia reading mode and adjustable line-height preview + slider in Appearance settings.
  * Reading progress bar for longform articles.
  * Kingfisher-based image loader for remote inline and block images with optional animation.

* **Improvements**
  * Markdown images now render as standalone block elements for better layout.
  * Improved sizing and layout for image-containing notes and longform content.
  * Display of estimated read time for longform articles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->