### PR TITLE
Add longform reading UX improvements

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -319,6 +319,8 @@
 		4CA5588329F33F5B00DC6A45 /* StringCodable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA5588229F33F5B00DC6A45 /* StringCodable.swift */; };
 		4CA9275D2A28FF630098A105 /* LongformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9275C2A28FF630098A105 /* LongformView.swift */; };
 		4CA9275F2A2902B20098A105 /* LongformPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9275E2A2902B20098A105 /* LongformPreview.swift */; };
+		5C78A7912E30358100CF177D /* ReadingProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C78A7902E30358000CF177D /* ReadingProgressBar.swift */; };
+		5C78A7952E30359100CF177D /* LongformMarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C78A7942E30359000CF177D /* LongformMarkdownView.swift */; };
 		4CA927612A290E340098A105 /* EventShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA927602A290E340098A105 /* EventShell.swift */; };
 		4CA927632A290EB10098A105 /* EventTop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA927622A290EB10098A105 /* EventTop.swift */; };
 		4CA927652A290F1A0098A105 /* TimeDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA927642A290F1A0098A105 /* TimeDot.swift */; };
@@ -1004,6 +1006,8 @@
 		82D6FC3A2CD99F7900C925F4 /* WideEventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFF8F6C29CD022E008DB934 /* WideEventView.swift */; };
 		82D6FC3B2CD99F7900C925F4 /* LongformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9275C2A28FF630098A105 /* LongformView.swift */; };
 		82D6FC3C2CD99F7900C925F4 /* LongformPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9275E2A2902B20098A105 /* LongformPreview.swift */; };
+		5C78A7922E30358200CF177D /* ReadingProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C78A7902E30358000CF177D /* ReadingProgressBar.swift */; };
+		5C78A7962E30359200CF177D /* LongformMarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C78A7942E30359000CF177D /* LongformMarkdownView.swift */; };
 		82D6FC3D2CD99F7900C925F4 /* EventShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA927602A290E340098A105 /* EventShell.swift */; };
 		82D6FC3E2CD99F7900C925F4 /* MentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC02AC4750B0080BA88 /* MentionView.swift */; };
 		82D6FC3F2CD99F7900C925F4 /* EventLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC22AC47EBC0080BA88 /* EventLoaderView.swift */; };
@@ -1550,6 +1554,8 @@
 		D73E5F352C6A97F4007EB227 /* WideEventView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFF8F6C29CD022E008DB934 /* WideEventView.swift */; };
 		D73E5F362C6A97F4007EB227 /* LongformView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9275C2A28FF630098A105 /* LongformView.swift */; };
 		D73E5F372C6A97F4007EB227 /* LongformPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9275E2A2902B20098A105 /* LongformPreview.swift */; };
+		5C78A7932E30358300CF177D /* ReadingProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C78A7902E30358000CF177D /* ReadingProgressBar.swift */; };
+		5C78A7972E30359300CF177D /* LongformMarkdownView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C78A7942E30359000CF177D /* LongformMarkdownView.swift */; };
 		D73E5F382C6A97F4007EB227 /* EventShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA927602A290E340098A105 /* EventShell.swift */; };
 		D73E5F392C6A97F4007EB227 /* MentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC02AC4750B0080BA88 /* MentionView.swift */; };
 		D73E5F3A2C6A97F4007EB227 /* EventLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC22AC47EBC0080BA88 /* EventLoaderView.swift */; };
@@ -2416,6 +2422,8 @@
 		4CA5588229F33F5B00DC6A45 /* StringCodable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringCodable.swift; sourceTree = "<group>"; };
 		4CA9275C2A28FF630098A105 /* LongformView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongformView.swift; sourceTree = "<group>"; };
 		4CA9275E2A2902B20098A105 /* LongformPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongformPreview.swift; sourceTree = "<group>"; };
+		5C78A7902E30358000CF177D /* ReadingProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadingProgressBar.swift; sourceTree = "<group>"; };
+		5C78A7942E30359000CF177D /* LongformMarkdownView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongformMarkdownView.swift; sourceTree = "<group>"; };
 		4CA927602A290E340098A105 /* EventShell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventShell.swift; sourceTree = "<group>"; };
 		4CA927622A290EB10098A105 /* EventTop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventTop.swift; sourceTree = "<group>"; };
 		4CA927642A290F1A0098A105 /* TimeDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeDot.swift; sourceTree = "<group>"; };
@@ -4348,6 +4356,8 @@
 			children = (
 				4CA9275C2A28FF630098A105 /* LongformView.swift */,
 				4CA9275E2A2902B20098A105 /* LongformPreview.swift */,
+				5C78A7902E30358000CF177D /* ReadingProgressBar.swift */,
+				5C78A7942E30359000CF177D /* LongformMarkdownView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -6144,6 +6154,8 @@
 				D7D09AB52DADCA5C00AB170D /* CoinosDeterministicAccountClient.swift in Sources */,
 				D773BC5F2C6D538500349F0A /* CommentItem.swift in Sources */,
 				4CA9275F2A2902B20098A105 /* LongformPreview.swift in Sources */,
+				5C78A7912E30358100CF177D /* ReadingProgressBar.swift in Sources */,
+				5C78A7952E30359100CF177D /* LongformMarkdownView.swift in Sources */,
 				4C5F9116283D855D0052CD1C /* EventsModel.swift in Sources */,
 				4C32B94F2A9AD44700DC3548 /* Int+extension.swift in Sources */,
 				4CEE2AED2805B22500AB5EEF /* NostrRequest.swift in Sources */,
@@ -6816,6 +6828,8 @@
 				82D6FC3A2CD99F7900C925F4 /* WideEventView.swift in Sources */,
 				82D6FC3B2CD99F7900C925F4 /* LongformView.swift in Sources */,
 				82D6FC3C2CD99F7900C925F4 /* LongformPreview.swift in Sources */,
+				5C78A7922E30358200CF177D /* ReadingProgressBar.swift in Sources */,
+				5C78A7962E30359200CF177D /* LongformMarkdownView.swift in Sources */,
 				D75154C22EC5910A00BF2CB2 /* NdbUseLock.swift in Sources */,
 				82D6FC3D2CD99F7900C925F4 /* EventShell.swift in Sources */,
 				82D6FC3E2CD99F7900C925F4 /* MentionView.swift in Sources */,
@@ -7254,6 +7268,8 @@
 				D73E5F8A2C6AA69C007EB227 /* SideMenuView.swift in Sources */,
 				D73E5F362C6A97F4007EB227 /* LongformView.swift in Sources */,
 				D73E5F372C6A97F4007EB227 /* LongformPreview.swift in Sources */,
+				5C78A7932E30358300CF177D /* ReadingProgressBar.swift in Sources */,
+				5C78A7972E30359300CF177D /* LongformMarkdownView.swift in Sources */,
 				D73E5F382C6A97F4007EB227 /* EventShell.swift in Sources */,
 				D73E5F882C6AA661007EB227 /* NostrScript.swift in Sources */,
 				D73E5F392C6A97F4007EB227 /* MentionView.swift in Sources */,

--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -627,6 +627,7 @@
 		7C60CAEF298471A1009C80D6 /* CoreSVG.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C60CAEE298471A1009C80D6 /* CoreSVG.swift */; };
 		7C902AE32981D55B002AB16E /* ZoomableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */; };
 		7C95CAEE299DCEF1009DCB67 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
+		K9G5YXAZ4Y19GSLH8TWS8CO1 /* KingfisherImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */; };
 		7CFF6317299FEFE5005D382A /* SelectableText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CFF6316299FEFE5005D382A /* SelectableText.swift */; };
 		82D6FA9A2CD9820500C925F4 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82D6FA992CD9820500C925F4 /* ShareViewController.swift */; };
 		82D6FAA12CD9820500C925F4 /* ShareExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 82D6FA972CD9820500C925F4 /* ShareExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -745,6 +746,7 @@
 		82D6FB2F2CD99F7900C925F4 /* BlurHashDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C198DEE29F88C6B004C165C /* BlurHashDecode.swift */; };
 		82D6FB302CD99F7900C925F4 /* PostBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE4F0F329D779B5005914DB /* PostBox.swift */; };
 		82D6FB312CD99F7900C925F4 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
+		FQ9UEENWE218BBQDVQXU3RA9 /* KingfisherImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */; };
 		82D6FB322CD99F7900C925F4 /* FillAndStroke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7D09752A0AF19E00943473 /* FillAndStroke.swift */; };
 		82D6FB332CD99F7900C925F4 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72E12772BEED22400F4F781 /* Array.swift */; };
 		82D6FB342CD99F7900C925F4 /* VectorMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78DB85A2C20FE4F00F0AB12 /* VectorMath.swift */; };
@@ -1360,6 +1362,7 @@
 		D73E5E632C6A97F4007EB227 /* BlurHashDecode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C198DEE29F88C6B004C165C /* BlurHashDecode.swift */; };
 		D73E5E642C6A97F4007EB227 /* PostBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CE4F0F329D779B5005914DB /* PostBox.swift */; };
 		D73E5E652C6A97F4007EB227 /* KFOptionSetter+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */; };
+		3RRUR7Z6M0UHAOFZTGU9GRU0 /* KingfisherImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */; };
 		D73E5E662C6A97F4007EB227 /* FillAndStroke.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7D09752A0AF19E00943473 /* FillAndStroke.swift */; };
 		D73E5E672C6A97F4007EB227 /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = D72E12772BEED22400F4F781 /* Array.swift */; };
 		D73E5E682C6A97F4007EB227 /* VectorMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78DB85A2C20FE4F00F0AB12 /* VectorMath.swift */; };
@@ -2684,6 +2687,7 @@
 		7C60CAEE298471A1009C80D6 /* CoreSVG.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreSVG.swift; sourceTree = "<group>"; };
 		7C902AE22981D55B002AB16E /* ZoomableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZoomableScrollView.swift; sourceTree = "<group>"; };
 		7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "KFOptionSetter+.swift"; sourceTree = "<group>"; };
+		BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KingfisherImageProvider.swift; sourceTree = "<group>"; };
 		7CFF6316299FEFE5005D382A /* SelectableText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectableText.swift; sourceTree = "<group>"; };
 		82D6FA972CD9820500C925F4 /* ShareExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = ShareExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		82D6FA992CD9820500C925F4 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
@@ -5100,6 +5104,7 @@
 			isa = PBXGroup;
 			children = (
 				7C95CAED299DCEF1009DCB67 /* KFOptionSetter+.swift */,
+				BAY65YZMB3VK8HOZYGCNV2YJ /* KingfisherImageProvider.swift */,
 				4C7D09752A0AF19E00943473 /* FillAndStroke.swift */,
 				D72E12772BEED22400F4F781 /* Array.swift */,
 				D78DB85A2C20FE4F00F0AB12 /* VectorMath.swift */,
@@ -5948,6 +5953,7 @@
 				4C0A3F93280F66F5000448DE /* ReplyMap.swift in Sources */,
 				4C2B7BF22A71B6540049DEE7 /* Id.swift in Sources */,
 				7C95CAEE299DCEF1009DCB67 /* KFOptionSetter+.swift in Sources */,
+				K9G5YXAZ4Y19GSLH8TWS8CO1 /* KingfisherImageProvider.swift in Sources */,
 				4C7D09722A0AEF5E00943473 /* DamusGradient.swift in Sources */,
 				4C463CBF2B960B96008A8C36 /* PurpleBackdrop.swift in Sources */,
 				5C8F97502EBD704A009399B1 /* LabsToggleView.swift in Sources */,
@@ -6506,6 +6512,7 @@
 				82D6FB302CD99F7900C925F4 /* PostBox.swift in Sources */,
 				5C8F970B2EB45E8C009399B1 /* LiveChatModel.swift in Sources */,
 				82D6FB312CD99F7900C925F4 /* KFOptionSetter+.swift in Sources */,
+				FQ9UEENWE218BBQDVQXU3RA9 /* KingfisherImageProvider.swift in Sources */,
 				5C8F972F2EB46116009399B1 /* LiveStreamStatus.swift in Sources */,
 				D73BDB162D71216500D69970 /* UserRelayListManager.swift in Sources */,
 				82D6FB322CD99F7900C925F4 /* FillAndStroke.swift in Sources */,
@@ -6986,6 +6993,7 @@
 				D76BE18E2E0CF3DA004AD0C6 /* Interests.swift in Sources */,
 				D73E5E642C6A97F4007EB227 /* PostBox.swift in Sources */,
 				D73E5E652C6A97F4007EB227 /* KFOptionSetter+.swift in Sources */,
+				3RRUR7Z6M0UHAOFZTGU9GRU0 /* KingfisherImageProvider.swift in Sources */,
 				D73E5E662C6A97F4007EB227 /* FillAndStroke.swift in Sources */,
 				D73E5E672C6A97F4007EB227 /* Array.swift in Sources */,
 				D73E5E682C6A97F4007EB227 /* VectorMath.swift in Sources */,

--- a/damus/Features/Chat/ChatroomThreadView.swift
+++ b/damus/Features/Chat/ChatroomThreadView.swift
@@ -391,6 +391,8 @@ struct ChatroomThreadView: View {
                 // Reset reading progress when switching to a different event
                 initialTopY = nil
                 readingProgress = 0
+                // Restore chrome when switching events (user tapped to select)
+                showChrome()
             }
             .onDisappear() {
                 thread.unsubscribe()

--- a/damus/Features/Chat/ChatroomThreadView.swift
+++ b/damus/Features/Chat/ChatroomThreadView.swift
@@ -205,7 +205,8 @@ struct ChatroomThreadView: View {
                             ThreadedSwipeViewGroup(scroller: scroller, events: trusted_events)
                         }
                     }
-                    .padding(.top)
+                    // Remove top padding for longform articles with sepia to eliminate gap
+                    .padding(.top, isLongformEvent && damus.settings.longform_sepia_mode ? 0 : nil)
 
                     // MARK: - Children view - outside trusted network
                     if !untrusted_events.isEmpty {

--- a/damus/Features/Chat/ChatroomThreadView.swift
+++ b/damus/Features/Chat/ChatroomThreadView.swift
@@ -69,22 +69,18 @@ struct ChatroomThreadView: View {
     }
 
     /// Updates chrome visibility based on scroll direction (longform only).
-    /// Scrolling down hides chrome, scrolling up shows it.
+    /// Scrolling down hides chrome; tap to restore (scroll up does not restore).
     private func updateChromeVisibility(newY: CGFloat) {
         guard isLongformEvent else { return }
 
         let delta = newY - lastScrollY
 
-        // Only toggle chrome state if scroll exceeds threshold
-        if abs(delta) > scrollThreshold {
-            let shouldHide = delta < 0  // Scrolling down (content moving up)
-
-            if shouldHide != chromeHidden {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    chromeHidden = shouldHide
-                }
-                notify(.display_tabbar(!shouldHide))
+        // Only hide chrome on scroll down, don't restore on scroll up (use tap instead)
+        if delta < -scrollThreshold && !chromeHidden {
+            withAnimation(.easeInOut(duration: 0.25)) {
+                chromeHidden = true
             }
+            notify(.display_tabbar(false))
         }
 
         // Always update lastScrollY to prevent stale delta accumulation

--- a/damus/Features/Chat/ChatroomThreadView.swift
+++ b/damus/Features/Chat/ChatroomThreadView.swift
@@ -290,6 +290,10 @@ struct ChatroomThreadView: View {
                                 viewportHeight = geo.size.height
                             }
                             .onChange(of: geo.size.height) { newHeight in
+                                // Reset baseline on significant height change (orientation, text size)
+                                if abs(newHeight - viewportHeight) > 50 {
+                                    initialTopY = nil
+                                }
                                 viewportHeight = newHeight
                                 updateReadingProgress()
                             }
@@ -336,6 +340,11 @@ struct ChatroomThreadView: View {
             .onAppear() {
                 thread.subscribe()
                 scroll_to_event(scroller: scroller, id: thread.selected_event.id, delay: 0.1, animate: false)
+            }
+            .onChange(of: thread.selected_event.id) { _ in
+                // Reset reading progress when switching to a different event
+                initialTopY = nil
+                readingProgress = 0
             }
             .onDisappear() {
                 thread.unsubscribe()

--- a/damus/Features/Events/Models/LoadableNostrEventView.swift
+++ b/damus/Features/Events/Models/LoadableNostrEventView.swift
@@ -78,7 +78,9 @@ class LoadableNostrEventViewModel: ObservableObject {
                 return .unknown_or_unsupported_kind
             }
         case .naddr(let naddr):
-            guard let event = await damus_state.nostrNetwork.reader.lookup(naddr: naddr) else { return .not_found }
+            guard let event = await damus_state.nostrNetwork.reader.lookup(naddr: naddr) else {
+                return .not_found
+            }
             return .loaded(route: Route.Thread(thread: ThreadModel(event: event, damus_state: damus_state)))
         }
     }

--- a/damus/Features/Events/Models/NoteContent.swift
+++ b/damus/Features/Events/Models/NoteContent.swift
@@ -381,6 +381,11 @@ struct LongformContent {
     let markdown: MarkdownContent
     let words: Int
 
+    /// Estimated reading time in minutes, based on average reading speed of 200 words per minute.
+    var estimatedReadTimeMinutes: Int {
+        return max(1, words / 200)
+    }
+
     init(_ markdown: String) {
         // Pre-process markdown to ensure images are block-level (have blank lines around them)
         // This prevents images from being parsed as inline within text paragraphs

--- a/damus/Features/Events/Models/NoteContent.swift
+++ b/damus/Features/Events/Models/NoteContent.swift
@@ -383,7 +383,7 @@ struct LongformContent {
 
     /// Estimated reading time in minutes, based on average reading speed of 200 words per minute.
     var estimatedReadTimeMinutes: Int {
-        return max(1, words / 200)
+        return max(1, Int(ceil(Double(words) / 200.0)))
     }
 
     init(_ markdown: String) {

--- a/damus/Features/Events/NoteContentView.swift
+++ b/damus/Features/Events/NoteContentView.swift
@@ -362,10 +362,13 @@ struct NoteContentView: View {
             switch self.note_artifacts {
             case .longform(let md):
                 // Note: Do NOT apply .fixedSize to longform content - it prevents async images from expanding
-                Markdown(md.markdown)
-                    .markdownImageProvider(.kingfisher(disable_animation: damus_state.settings.disable_animation))
-                    .markdownInlineImageProvider(.kingfisher)
-                    .padding([.leading, .trailing, .top])
+                // Limit line length to ~600pt for optimal readability (50-75 chars per line)
+                LongformMarkdownView(
+                    markdown: md.markdown,
+                    disableAnimation: damus_state.settings.disable_animation,
+                    lineHeightMultiplier: damus_state.settings.longform_line_height,
+                    sepiaEnabled: damus_state.settings.longform_sepia_mode
+                )
             case .separated(let separated):
                 if #available(iOS 17.4, macOS 14.4, *) {
                     MainContent(artifacts: separated)

--- a/damus/Features/Events/NoteContentView.swift
+++ b/damus/Features/Events/NoteContentView.swift
@@ -361,7 +361,10 @@ struct NoteContentView: View {
         Group {
             switch self.note_artifacts {
             case .longform(let md):
+                // Note: Do NOT apply .fixedSize to longform content - it prevents async images from expanding
                 Markdown(md.markdown)
+                    .markdownImageProvider(.kingfisher(disable_animation: damus_state.settings.disable_animation))
+                    .markdownInlineImageProvider(.kingfisher)
                     .padding([.leading, .trailing, .top])
             case .separated(let separated):
                 if #available(iOS 17.4, macOS 14.4, *) {
@@ -369,12 +372,13 @@ struct NoteContentView: View {
 #if !targetEnvironment(macCatalyst)
                         .translationPresentation(isPresented: $isAppleTranslationPopoverPresented, text: event.get_content(damus_state.keypair))
 #endif
+                        .fixedSize(horizontal: false, vertical: true)
                 } else {
                     MainContent(artifacts: separated)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
             }
         }
-        .fixedSize(horizontal: false, vertical: true)
     }
 
     var normalizedHighlightTerms: [String] {

--- a/damus/Features/Events/SelectedEventView.swift
+++ b/damus/Features/Events/SelectedEventView.swift
@@ -11,12 +11,19 @@ struct SelectedEventView: View {
     let damus: DamusState
     let event: NostrEvent
     let size: EventViewKind
-    
+
+    @Environment(\.colorScheme) var colorScheme
+
     var pubkey: Pubkey {
         event.pubkey
     }
-    
+
     @StateObject var bar: ActionBarModel
+
+    /// Whether to apply sepia styling to the entire view (for longform articles)
+    var useSepia: Bool {
+        event.known_kind == .longform && damus.settings.longform_sepia_mode
+    }
 
     init(damus: DamusState, event: NostrEvent, size: EventViewKind) {
         self.damus = damus
@@ -24,7 +31,7 @@ struct SelectedEventView: View {
         self.size = size
         self._bar = StateObject(wrappedValue: make_actionbar_model(ev: event.id, damus: damus))
     }
-    
+
     var body: some View {
         HStack(alignment: .top) {
             VStack(alignment: .leading) {
@@ -78,6 +85,10 @@ struct SelectedEventView: View {
             }
             .compositingGroup()
         }
+        // Apply sepia background to outer HStack for full width coverage
+        // Note: foregroundStyle intentionally NOT applied here to preserve UI element contrast
+        // (buttons, icons, timestamps). Article text gets sepia styling via EventBody.
+        .background(useSepia ? DamusColors.sepiaBackground(for: colorScheme) : Color.clear)
     }
     
     var Mention: some View {

--- a/damus/Features/Longform/Views/LongformMarkdownView.swift
+++ b/damus/Features/Longform/Views/LongformMarkdownView.swift
@@ -1,0 +1,42 @@
+//
+//  LongformMarkdownView.swift
+//  damus
+//
+//  Created by Claude on 2026-01-03.
+//
+
+import SwiftUI
+import MarkdownUI
+
+/// A view that renders longform markdown content with optional sepia mode that adapts to light/dark color scheme.
+struct LongformMarkdownView: View {
+    let markdown: MarkdownContent
+    let disableAnimation: Bool
+    /// Line height multiplier (e.g., 1.5 means 1.5x line height)
+    let lineHeightMultiplier: CGFloat
+    let sepiaEnabled: Bool
+
+    @Environment(\.colorScheme) var colorScheme
+
+    /// Relative line spacing in em units (1.5x multiplier = 0.5em extra spacing)
+    private var relativeLineSpacing: CGFloat {
+        lineHeightMultiplier - 1.0
+    }
+
+    var body: some View {
+        Markdown(markdown)
+            // Override only paragraph style, preserving all other default formatting (headings, lists, etc.)
+            .markdownBlockStyle(\.paragraph) { configuration in
+                configuration.label
+                    .relativeLineSpacing(.em(relativeLineSpacing))
+                    .markdownMargin(top: 0, bottom: 16)
+            }
+            .markdownImageProvider(.kingfisher(disable_animation: disableAnimation))
+            .markdownInlineImageProvider(.kingfisher)
+            .frame(maxWidth: 600, alignment: .leading)
+            .frame(maxWidth: .infinity)
+            .padding([.leading, .trailing, .top])
+            .background(sepiaEnabled ? DamusColors.sepiaBackground(for: colorScheme) : Color.clear)
+            .foregroundStyle(sepiaEnabled ? DamusColors.sepiaText(for: colorScheme) : Color.primary)
+    }
+}

--- a/damus/Features/Longform/Views/LongformMarkdownView.swift
+++ b/damus/Features/Longform/Views/LongformMarkdownView.swift
@@ -19,24 +19,30 @@ struct LongformMarkdownView: View {
     @Environment(\.colorScheme) var colorScheme
 
     /// Relative line spacing in em units (1.5x multiplier = 0.5em extra spacing)
+    /// Guarded against negative values for safety
     private var relativeLineSpacing: CGFloat {
-        lineHeightMultiplier - 1.0
+        max(0, lineHeightMultiplier - 1.0)
     }
 
     var body: some View {
-        Markdown(markdown)
-            // Override only paragraph style, preserving all other default formatting (headings, lists, etc.)
-            .markdownBlockStyle(\.paragraph) { configuration in
-                configuration.label
-                    .relativeLineSpacing(.em(relativeLineSpacing))
-                    .markdownMargin(top: 0, bottom: 16)
-            }
-            .markdownImageProvider(.kingfisher(disable_animation: disableAnimation))
-            .markdownInlineImageProvider(.kingfisher)
-            .frame(maxWidth: 600, alignment: .leading)
-            .frame(maxWidth: .infinity)
-            .padding([.leading, .trailing, .top])
-            .background(sepiaEnabled ? DamusColors.sepiaBackground(for: colorScheme) : Color.clear)
-            .foregroundStyle(sepiaEnabled ? DamusColors.sepiaText(for: colorScheme) : Color.primary)
+        // Full-width background container
+        HStack(spacing: 0) {
+            Spacer(minLength: 0)
+            Markdown(markdown)
+                // Override only paragraph style, preserving all other default formatting (headings, lists, etc.)
+                .markdownBlockStyle(\.paragraph) { configuration in
+                    configuration.label
+                        .relativeLineSpacing(.em(relativeLineSpacing))
+                        .markdownMargin(top: 0, bottom: 16)
+                }
+                .markdownImageProvider(.kingfisher(disable_animation: disableAnimation))
+                .markdownInlineImageProvider(.kingfisher)
+                .frame(maxWidth: 600, alignment: .leading)
+                .padding([.leading, .trailing])
+            Spacer(minLength: 0)
+        }
+        .padding(.top)
+        .background(sepiaEnabled ? DamusColors.sepiaBackground(for: colorScheme) : Color.clear)
+        .foregroundStyle(sepiaEnabled ? DamusColors.sepiaText(for: colorScheme) : Color.primary)
     }
 }

--- a/damus/Features/Longform/Views/LongformPreview.swift
+++ b/damus/Features/Longform/Views/LongformPreview.swift
@@ -13,24 +13,28 @@ struct LongformPreviewBody: View {
     let event: LongformEvent
     let options: EventViewOptions
     let header: Bool
+    let sepiaEnabled: Bool
     @State var blur_images: Bool = true
-    
-    @ObservedObject var artifacts: NoteArtifactsModel
 
-    init(state: DamusState, ev: LongformEvent, options: EventViewOptions, header: Bool) {
+    @ObservedObject var artifacts: NoteArtifactsModel
+    @Environment(\.colorScheme) var colorScheme
+
+    init(state: DamusState, ev: LongformEvent, options: EventViewOptions, header: Bool, sepiaEnabled: Bool = false) {
         self.state = state
         self.event = ev
         self.options = options
         self.header = header
+        self.sepiaEnabled = sepiaEnabled
 
         self._artifacts = ObservedObject(wrappedValue: state.events.get_cache_data(ev.event.id).artifacts_model)
     }
 
-    init(state: DamusState, ev: NostrEvent, options: EventViewOptions, header: Bool) {
+    init(state: DamusState, ev: NostrEvent, options: EventViewOptions, header: Bool, sepiaEnabled: Bool = false) {
         self.state = state
         self.event = LongformEvent.parse(from: ev)
         self.options = options
         self.header = header
+        self.sepiaEnabled = sepiaEnabled
 
         self._artifacts = ObservedObject(wrappedValue: state.events.get_cache_data(ev.id).artifacts_model)
     }
@@ -110,13 +114,87 @@ struct LongformPreviewBody: View {
     }
 
     var body: some View {
-        Group {
-            if options.contains(.wide) {
-                Main.padding(.horizontal)
-            } else {
-                Main
+        // In full article view with sepia, wrap in full-width container for seamless background
+        let fullWidthSepia = !truncate && sepiaEnabled
+
+        if fullWidthSepia {
+            // Full-width sepia background container
+            MainContent
+                .padding(.horizontal)
+                .frame(maxWidth: .infinity)
+                .background(DamusColors.sepiaBackground(for: colorScheme))
+                .foregroundStyle(DamusColors.sepiaText(for: colorScheme))
+        } else {
+            Group {
+                if options.contains(.wide) {
+                    Main.padding(.horizontal)
+                } else {
+                    Main
+                }
             }
         }
+    }
+
+    /// Content without card styling - for use in full-width sepia container
+    var MainContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            if let url = event.image {
+                if (self.options.contains(.no_media)) {
+                    EmptyView()
+                } else if !blur_images || (!blur_images && !state.settings.media_previews) {
+                    titleImage(url: url)
+                } else if blur_images || (blur_images && !state.settings.media_previews) {
+                    ZStack {
+                        titleImage(url: url)
+                        BlurOverlayView(blur_images: $blur_images, artifacts: nil, size: nil, damus_state: nil, parentView: .longFormView)
+                    }
+                }
+            }
+
+            Text(event.title ?? NSLocalizedString("Untitled", comment: "Title of longform event if it is untitled."))
+                .font(header ? .title : .headline)
+                .padding(.horizontal, 10)
+                .padding(.top, 5)
+
+            if let summary = event.summary {
+                truncatedText(content: CompatibleText(stringLiteral: summary))
+            }
+
+            if let labels = event.labels {
+                ScrollView(.horizontal) {
+                    HStack {
+                        ForEach(labels, id: \.self) { label in
+                            Text(label)
+                                .font(.caption)
+                                .foregroundColor(DamusColors.sepiaText(for: colorScheme).opacity(0.7))
+                                .padding(EdgeInsets(top: 5, leading: 15, bottom: 5, trailing: 15))
+                                .background(DamusColors.sepiaText(for: colorScheme).opacity(0.1))
+                                .cornerRadius(20)
+                                .overlay(
+                                    RoundedRectangle(cornerRadius: 20)
+                                        .stroke(DamusColors.sepiaText(for: colorScheme).opacity(0.3), lineWidth: 1)
+                                )
+                        }
+                    }
+                }
+                .scrollIndicators(.hidden)
+                .padding(10)
+            }
+
+            if case .loaded(let arts) = artifacts.state,
+               case .longform(let longform) = arts
+            {
+                HStack(spacing: 8) {
+                    ReadTime(longform.estimatedReadTimeMinutes)
+                    Text("·")
+                    Words(longform.words)
+                }
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .padding([.horizontal, .bottom], 10)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     var Main: some View {
@@ -147,15 +225,17 @@ struct LongformPreviewBody: View {
                 ScrollView(.horizontal) {
                     HStack {
                         ForEach(labels, id: \.self) { label in
+                            // In full article view with sepia, use subtle sepia-tinted tag styling
+                            let useSepiaTags = !truncate && sepiaEnabled
                             Text(label)
                                 .font(.caption)
-                                .foregroundColor(.gray)
+                                .foregroundColor(useSepiaTags ? DamusColors.sepiaText(for: colorScheme).opacity(0.7) : .gray)
                                 .padding(EdgeInsets(top: 5, leading: 15, bottom: 5, trailing: 15))
-                                .background(DamusColors.neutral1)
+                                .background(useSepiaTags ? DamusColors.sepiaText(for: colorScheme).opacity(0.1) : DamusColors.neutral1)
                                 .cornerRadius(20)
                                 .overlay(
                                     RoundedRectangle(cornerRadius: 20)
-                                        .stroke(DamusColors.neutral3, lineWidth: 1)
+                                        .stroke(useSepiaTags ? DamusColors.sepiaText(for: colorScheme).opacity(0.3) : DamusColors.neutral3, lineWidth: 1)
                                 )
                         }
                     }
@@ -179,13 +259,18 @@ struct LongformPreviewBody: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(DamusColors.neutral3)
-        .cornerRadius(10)
+        // Only show card styling when content is truncated (preview mode)
+        // In full article view, use sepia background if enabled, otherwise clear
+        .background(truncate ? DamusColors.neutral3 : (sepiaEnabled ? DamusColors.sepiaBackground(for: colorScheme) : Color.clear))
+        .foregroundStyle(truncate ? Color.primary : (sepiaEnabled ? DamusColors.sepiaText(for: colorScheme) : Color.primary))
+        .cornerRadius(truncate ? 10 : 0)
         .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(DamusColors.neutral1, lineWidth: 1)
+            truncate ?
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(DamusColors.neutral1, lineWidth: 1)
+                : nil
         )
-        .padding(.top, 10)
+        .padding(.top, truncate ? 10 : 0)
         .onAppear {
             blur_images = should_blur_images(settings: state.settings, contacts: state.contacts, ev: event.event, our_pubkey: state.pubkey)
         }

--- a/damus/Features/Longform/Views/LongformPreview.swift
+++ b/damus/Features/Longform/Views/LongformPreview.swift
@@ -139,11 +139,11 @@ struct LongformPreviewBody: View {
     var MainContent: some View {
         VStack(alignment: .leading, spacing: 10) {
             if let url = event.image {
-                if (self.options.contains(.no_media)) {
+                if self.options.contains(.no_media) {
                     EmptyView()
-                } else if !blur_images || (!blur_images && !state.settings.media_previews) {
+                } else if !blur_images {
                     titleImage(url: url)
-                } else if blur_images || (blur_images && !state.settings.media_previews) {
+                } else {
                     ZStack {
                         titleImage(url: url)
                         BlurOverlayView(blur_images: $blur_images, artifacts: nil, size: nil, damus_state: nil, parentView: .longFormView)
@@ -200,18 +200,18 @@ struct LongformPreviewBody: View {
     var Main: some View {
         VStack(alignment: .leading, spacing: 10) {
             if let url = event.image {
-                if (self.options.contains(.no_media)) {
+                if self.options.contains(.no_media) {
                     EmptyView()
-                } else if !blur_images || (!blur_images && !state.settings.media_previews) {
+                } else if !blur_images {
                     titleImage(url: url)
-                } else if blur_images || (blur_images && !state.settings.media_previews) {
+                } else {
                     ZStack {
                         titleImage(url: url)
                         BlurOverlayView(blur_images: $blur_images, artifacts: nil, size: nil, damus_state: nil, parentView: .longFormView)
                     }
                 }
             }
-            
+
             Text(event.title ?? NSLocalizedString("Untitled", comment: "Title of longform event if it is untitled."))
                 .font(header ? .title : .headline)
                 .padding(.horizontal, 10)

--- a/damus/Features/Longform/Views/LongformPreview.swift
+++ b/damus/Features/Longform/Views/LongformPreview.swift
@@ -35,9 +35,16 @@ struct LongformPreviewBody: View {
         self._artifacts = ObservedObject(wrappedValue: state.events.get_cache_data(ev.id).artifacts_model)
     }
 
+    /// Formats word count for display.
     func Words(_ words: Int) -> Text {
         let wordCount = pluralizedString(key: "word_count", count: words)
         return Text(wordCount)
+    }
+
+    /// Formats estimated read time for display.
+    func ReadTime(_ minutes: Int) -> Text {
+        let readTime = pluralizedString(key: "read_time", count: minutes)
+        return Text(readTime)
     }
     
     var truncate: Bool {
@@ -161,8 +168,14 @@ struct LongformPreviewBody: View {
             if case .loaded(let arts) = artifacts.state,
                case .longform(let longform) = arts
             {
-                Words(longform.words).font(.footnote)
-                    .padding([.horizontal, .bottom], 10)
+                HStack(spacing: 8) {
+                    ReadTime(longform.estimatedReadTimeMinutes)
+                    Text("·")
+                    Words(longform.words)
+                }
+                .font(.footnote)
+                .foregroundColor(.gray)
+                .padding([.horizontal, .bottom], 10)
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/damus/Features/Longform/Views/LongformView.swift
+++ b/damus/Features/Longform/Views/LongformView.swift
@@ -11,13 +11,13 @@ struct LongformView: View {
     let state: DamusState
     let event: LongformEvent
     @ObservedObject var artifacts: NoteArtifactsModel
-    
+
     init(state: DamusState, event: LongformEvent, artifacts: NoteArtifactsModel? = nil) {
         self.state = state
         self.event = event
         self._artifacts = ObservedObject(wrappedValue: artifacts ?? state.events.get_cache_data(event.event.id).artifacts_model)
     }
-    
+
     var options: EventViewOptions {
         return [.wide, .no_mentions, .no_replying_to]
     }

--- a/damus/Features/Longform/Views/ReadingProgressBar.swift
+++ b/damus/Features/Longform/Views/ReadingProgressBar.swift
@@ -1,0 +1,37 @@
+//
+//  ReadingProgressBar.swift
+//  damus
+//
+//  Created by Claude on 2026-01-03.
+//
+
+import SwiftUI
+
+/// A thin progress bar that indicates reading progress through longform content.
+struct ReadingProgressBar: View {
+    /// Reading progress from 0.0 to 1.0.
+    let progress: CGFloat
+
+    var body: some View {
+        GeometryReader { geometry in
+            Rectangle()
+                .fill(DamusColors.purple)
+                .frame(width: geometry.size.width * min(max(progress, 0), 1))
+        }
+        .frame(height: 4)
+        .background(Color.gray.opacity(0.3))
+    }
+}
+
+struct ReadingProgressBar_Previews: PreviewProvider {
+    static var previews: some View {
+        VStack(spacing: 20) {
+            ReadingProgressBar(progress: 0)
+            ReadingProgressBar(progress: 0.25)
+            ReadingProgressBar(progress: 0.5)
+            ReadingProgressBar(progress: 0.75)
+            ReadingProgressBar(progress: 1.0)
+        }
+        .padding()
+    }
+}

--- a/damus/Features/Settings/Models/UserSettingsStore.swift
+++ b/damus/Features/Settings/Models/UserSettingsStore.swift
@@ -166,6 +166,12 @@ class UserSettingsStore: ObservableObject {
     @Setting(key: "font_size", default_value: 1.0)
     var font_size: Double
 
+    @Setting(key: "longform_sepia_mode", default_value: false)
+    var longform_sepia_mode: Bool
+
+    @Setting(key: "longform_line_height", default_value: 1.5)
+    var longform_line_height: Double
+
     @Setting(key: "dm_notification", default_value: true)
     var dm_notification: Bool
     

--- a/damus/Features/Settings/Views/AppearanceSettingsView.swift
+++ b/damus/Features/Settings/Views/AppearanceSettingsView.swift
@@ -26,6 +26,35 @@ struct ResizedEventPreview: View {
     }
 }
 
+/// Preview component showing sample text with the current line height setting applied
+struct LineHeightPreview: View {
+    let lineHeight: Double
+    let sepiaEnabled: Bool
+    @Environment(\.colorScheme) var colorScheme
+
+    private let sampleText = NSLocalizedString(
+        "The quick brown fox jumps over the lazy dog. This preview shows how your line spacing will appear in longform articles.",
+        comment: "Sample text for line height preview in settings"
+    )
+
+    var body: some View {
+        let font = Font.body
+        // Use Dynamic Type: get actual body font size from system preferences
+        let baseFontSize = UIFont.preferredFont(forTextStyle: .body).pointSize
+        let spacing = baseFontSize * (lineHeight - 1.0)
+
+        Text(sampleText)
+            .font(font)
+            .lineSpacing(spacing)
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(sepiaEnabled ? DamusColors.sepiaBackground(for: colorScheme) : Color(UIColor.secondarySystemBackground))
+            .foregroundStyle(sepiaEnabled ? DamusColors.sepiaText(for: colorScheme) : Color.primary)
+            .cornerRadius(8)
+            .padding(.top, 8)
+    }
+}
+
 struct AppearanceSettingsView: View {
     let damus_state: DamusState
     @ObservedObject var settings: UserSettingsStore
@@ -51,6 +80,20 @@ struct AppearanceSettingsView: View {
         Form {
             Section(NSLocalizedString("Font Size", comment: "Section label for font size settings.")) {
                 FontSize
+            }
+
+            // MARK: - Reading
+            Section(header: Text("Reading", comment: "Section header for reading appearance settings")) {
+                Toggle(NSLocalizedString("Sepia mode for longform articles", comment: "Setting to enable sepia reading mode for longform articles"), isOn: $settings.longform_sepia_mode)
+                    .toggleStyle(.switch)
+
+                VStack(alignment: .leading) {
+                    Text(String(format: NSLocalizedString("Line height: %.1fx", comment: "Label showing current line height multiplier setting"), settings.longform_line_height))
+                    Slider(value: $settings.longform_line_height, in: 1.2...1.8, step: 0.1)
+
+                    // Preview of line height
+                    LineHeightPreview(lineHeight: settings.longform_line_height, sepiaEnabled: settings.longform_sepia_mode)
+                }
             }
 
             // MARK: - Text Truncation

--- a/damus/Shared/Components/DamusColors.swift
+++ b/damus/Shared/Components/DamusColors.swift
@@ -60,6 +60,24 @@ class DamusColors {
     static let pink = Color(red: 211/255.0, green: 76/255.0, blue: 217/255.0)
     static let lighterPink = Color(red: 248/255.0, green: 105/255.0, blue: 182/255.0)
     static let lightBackgroundPink = Color(red: 0xF8/255.0, green: 0xE7/255.0, blue: 0xF8/255.0)
+
+    // Sepia mode colors for comfortable longform reading (based on research: 25% lower luminescence reduces eye strain)
+    // Light mode sepia
+    static let sepiaBackgroundLight = Color(red: 0.98, green: 0.95, blue: 0.90)  // #FAF3E6 - warm off-white
+    static let sepiaTextLight = Color(red: 0.35, green: 0.27, blue: 0.20)  // #5A4632 - warm brown
+    // Dark mode sepia (subtle warm tint that blends with dark UI)
+    static let sepiaBackgroundDark = Color(red: 0.08, green: 0.07, blue: 0.06)  // Near-black with subtle warmth
+    static let sepiaTextDark = Color(red: 0.85, green: 0.80, blue: 0.72)  // Warm off-white text
+
+    /// Returns appropriate sepia background for current color scheme.
+    static func sepiaBackground(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? sepiaBackgroundDark : sepiaBackgroundLight
+    }
+
+    /// Returns appropriate sepia text color for current color scheme.
+    static func sepiaText(for colorScheme: ColorScheme) -> Color {
+        colorScheme == .dark ? sepiaTextDark : sepiaTextLight
+    }
 }
 
 func hex_col(r: UInt8, g: UInt8, b: UInt8) -> Color {

--- a/damus/Shared/Components/DamusColors.swift
+++ b/damus/Shared/Components/DamusColors.swift
@@ -61,7 +61,7 @@ class DamusColors {
     static let lighterPink = Color(red: 248/255.0, green: 105/255.0, blue: 182/255.0)
     static let lightBackgroundPink = Color(red: 0xF8/255.0, green: 0xE7/255.0, blue: 0xF8/255.0)
 
-    // Sepia mode colors for comfortable longform reading (based on research: 25% lower luminescence reduces eye strain)
+    // Sepia mode colors for comfortable longform reading
     // Light mode sepia
     static let sepiaBackgroundLight = Color(red: 0.98, green: 0.95, blue: 0.90)  // #FAF3E6 - warm off-white
     static let sepiaTextLight = Color(red: 0.35, green: 0.27, blue: 0.20)  // #5A4632 - warm brown

--- a/damus/Shared/Extensions/KingfisherImageProvider.swift
+++ b/damus/Shared/Extensions/KingfisherImageProvider.swift
@@ -1,0 +1,98 @@
+//
+//  KingfisherImageProvider.swift
+//  damus
+//
+//  Created by alltheseas on 2026-01-03.
+//
+
+import SwiftUI
+import Kingfisher
+import MarkdownUI
+
+/// A custom image provider for MarkdownUI that uses Kingfisher for image loading.
+/// This provides proper aspect ratio handling and caching for images in longform markdown content.
+struct KingfisherImageProvider: ImageProvider {
+    let disable_animation: Bool
+
+    init(disable_animation: Bool = false) {
+        self.disable_animation = disable_animation
+    }
+
+    func makeImage(url: URL?) -> some View {
+        KingfisherMarkdownImage(url: url, disable_animation: disable_animation)
+    }
+}
+
+extension ImageProvider where Self == KingfisherImageProvider {
+    /// A Kingfisher-based image provider for loading images with proper caching and aspect ratio handling.
+    static var kingfisher: Self { .init() }
+
+    /// A Kingfisher-based image provider with animation disabled.
+    static func kingfisher(disable_animation: Bool) -> Self {
+        .init(disable_animation: disable_animation)
+    }
+}
+
+// MARK: - InlineImageProvider (for images mixed with text)
+
+/// A custom inline image provider for MarkdownUI that uses Kingfisher for loading inline images.
+/// This handles images that appear within text content (not standalone image paragraphs).
+struct KingfisherInlineImageProvider: InlineImageProvider {
+    func image(with url: URL, label: String) async throws -> Image {
+        return try await withCheckedThrowingContinuation { continuation in
+            KingfisherManager.shared.retrieveImage(with: url) { result in
+                switch result {
+                case .success(let imageResult):
+                    continuation.resume(returning: Image(uiImage: imageResult.image))
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+}
+
+extension InlineImageProvider where Self == KingfisherInlineImageProvider {
+    /// A Kingfisher-based inline image provider for loading images within text.
+    static var kingfisher: Self { .init() }
+}
+
+// MARK: - ImageProvider View (for standalone image paragraphs)
+
+/// Internal view that handles the actual Kingfisher image loading for markdown content.
+/// Uses state to track loaded image dimensions for proper aspect ratio sizing.
+private struct KingfisherMarkdownImage: View {
+    let url: URL?
+    let disable_animation: Bool
+    @State private var imageSize: CGSize?
+
+    /// Returns a valid aspect ratio, guarding against zero/invalid dimensions.
+    private var safeAspectRatio: CGSize {
+        guard let size = imageSize, size.width > 0, size.height > 0 else {
+            return CGSize(width: 1, height: 1)
+        }
+        return size
+    }
+
+    var body: some View {
+        if let url {
+            KFAnimatedImage(url)
+                .callbackQueue(.dispatch(.global(qos: .background)))
+                .backgroundDecode(true)
+                .imageContext(.note, disable_animation: disable_animation)
+                .image_fade(duration: 0.25)
+                .cancelOnDisappear(true)
+                .configure { view in
+                    view.framePreloadCount = 3
+                }
+                .observe_image_size { size in
+                    imageSize = size
+                }
+                .aspectRatio(safeAspectRatio, contentMode: .fit)
+                .frame(maxWidth: .infinity)
+                .kfClickable()
+        } else {
+            EmptyView()
+        }
+    }
+}

--- a/damus/en-US.lproj/Localizable.stringsdict
+++ b/damus/en-US.lproj/Localizable.stringsdict
@@ -386,6 +386,22 @@
 			<string>%d Words</string>
 		</dict>
 	</dict>
+	<key>read_time</key>
+	<dict>
+		<key>NSStringLocalizedFormatKey</key>
+		<string>%#@MINUTES@</string>
+		<key>MINUTES</key>
+		<dict>
+			<key>NSStringFormatSpecTypeKey</key>
+			<string>NSStringPluralRuleType</string>
+			<key>NSStringFormatValueTypeKey</key>
+			<string>d</string>
+			<key>one</key>
+			<string>%d min read</string>
+			<key>other</key>
+			<string>%d min read</string>
+		</dict>
+	</dict>
 	<key>zap_notification_no_message</key>
 	<dict>
 		<key>NSStringLocalizedFormatKey</key>


### PR DESCRIPTION
## Summary
- Add reading progress bar for longform articles (kind 30023)
- Add estimated read time to longform preview with word count
- Add sepia mode and line height settings for comfortable reading
- Add Dynamic Type support for accessibility
- Remove card styling in full article view for seamless sepia experience

**Stacked on:** #12

## Test plan
- [ ] Open a longform article and verify progress bar tracks scroll position (0% → 100%)
- [ ] Verify estimated read time shows in preview (e.g., "5 min read")
- [ ] Toggle sepia mode in Appearance settings and verify full-width background
- [ ] Adjust line height slider and verify it affects article content
- [ ] Test in both light and dark mode
- [ ] Test with different Dynamic Type sizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reading progress bar shows your position while reading longform articles; tap to reveal chrome/navigation.
  * Sepia mode for longform with light/dark variants and full‑width presentation.
  * Adjustable line height (1.2–1.8) with live preview in Appearance settings.
  * Estimated read time displayed for longform content.
  * Improved longform rendering for Markdown and media to enhance readability and layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->