### PR TITLE
Display longform article preview cards for naddr/nevent references

### DIFF
--- a/damus.xcodeproj/project.pbxproj
+++ b/damus.xcodeproj/project.pbxproj
@@ -1004,6 +1004,7 @@
 		82D6FC3C2CD99F7900C925F4 /* LongformPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9275E2A2902B20098A105 /* LongformPreview.swift */; };
 		82D6FC3D2CD99F7900C925F4 /* EventShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA927602A290E340098A105 /* EventShell.swift */; };
 		82D6FC3E2CD99F7900C925F4 /* MentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC02AC4750B0080BA88 /* MentionView.swift */; };
+		82D6FC3E2CD99F7900C925F5 /* LongformNaddrMentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC12AC4750C0080BA89 /* LongformNaddrMentionView.swift */; };
 		82D6FC3F2CD99F7900C925F4 /* EventLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC22AC47EBC0080BA88 /* EventLoaderView.swift */; };
 		82D6FC402CD99F7900C925F4 /* RepostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA24801297E3DC20090C62D /* RepostView.swift */; };
 		82D6FC412CD99F7900C925F4 /* RepostedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFF8F6A29CD0079008DB934 /* RepostedEvent.swift */; };
@@ -1549,6 +1550,7 @@
 		D73E5F372C6A97F4007EB227 /* LongformPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA9275E2A2902B20098A105 /* LongformPreview.swift */; };
 		D73E5F382C6A97F4007EB227 /* EventShell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CA927602A290E340098A105 /* EventShell.swift */; };
 		D73E5F392C6A97F4007EB227 /* MentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC02AC4750B0080BA88 /* MentionView.swift */; };
+		D73E5F392C6A97F4007EB228 /* LongformNaddrMentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC12AC4750C0080BA89 /* LongformNaddrMentionView.swift */; };
 		D73E5F3A2C6A97F4007EB227 /* EventLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC22AC47EBC0080BA88 /* EventLoaderView.swift */; };
 		D73E5F3B2C6A97F4007EB227 /* RepostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA24801297E3DC20090C62D /* RepostView.swift */; };
 		D73E5F3C2C6A97F4007EB227 /* RepostedEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CFF8F6A29CD0079008DB934 /* RepostedEvent.swift */; };
@@ -1694,6 +1696,7 @@
 		D783A63F2AD4E53D00658DDA /* SuggestedHashtagsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D783A63E2AD4E53D00658DDA /* SuggestedHashtagsView.swift */; };
 		D78525252A7B2EA4002FA637 /* NoteContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78525242A7B2EA4002FA637 /* NoteContentViewTests.swift */; };
 		D7870BC12AC4750B0080BA88 /* MentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC02AC4750B0080BA88 /* MentionView.swift */; };
+		D7870BC42AC4750D0080BA89 /* LongformNaddrMentionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC12AC4750C0080BA89 /* LongformNaddrMentionView.swift */; };
 		D7870BC32AC47EBC0080BA88 /* EventLoaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7870BC22AC47EBC0080BA88 /* EventLoaderView.swift */; };
 		D789D1202AFEFBF20083A7AB /* secp256k1 in Frameworks */ = {isa = PBXBuildFile; productRef = D789D11F2AFEFBF20083A7AB /* secp256k1 */; };
 		D78BA6652DD7DFB9000AE62C /* InterestSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78BA6642DD7DFB9000AE62C /* InterestSelectionView.swift */; };
@@ -2795,6 +2798,7 @@
 		D783A63E2AD4E53D00658DDA /* SuggestedHashtagsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuggestedHashtagsView.swift; sourceTree = "<group>"; };
 		D78525242A7B2EA4002FA637 /* NoteContentViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoteContentViewTests.swift; sourceTree = "<group>"; };
 		D7870BC02AC4750B0080BA88 /* MentionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MentionView.swift; sourceTree = "<group>"; };
+		D7870BC12AC4750C0080BA89 /* LongformNaddrMentionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LongformNaddrMentionView.swift; sourceTree = "<group>"; };
 		D7870BC22AC47EBC0080BA88 /* EventLoaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventLoaderView.swift; sourceTree = "<group>"; };
 		D78BA6642DD7DFB9000AE62C /* InterestSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InterestSelectionView.swift; sourceTree = "<group>"; };
 		D78CD5972B8990300014D539 /* DamusAppNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DamusAppNotificationView.swift; sourceTree = "<group>"; };
@@ -3707,6 +3711,7 @@
 				4CFF8F6C29CD022E008DB934 /* WideEventView.swift */,
 				4CA927602A290E340098A105 /* EventShell.swift */,
 				D7870BC02AC4750B0080BA88 /* MentionView.swift */,
+				D7870BC12AC4750C0080BA89 /* LongformNaddrMentionView.swift */,
 				D7870BC22AC47EBC0080BA88 /* EventLoaderView.swift */,
 				4CEE2AF0280B216B00AB5EEF /* EventDetailView.swift */,
 				4C75EFB82804A2740006080F /* EventView.swift */,
@@ -5787,6 +5792,7 @@
 				3A8CC6CC2A2CFEF900940F5F /* StringUtil.swift in Sources */,
 				D7FD12262BD345A700CF195B /* FirstAidSettingsView.swift in Sources */,
 				D7870BC12AC4750B0080BA88 /* MentionView.swift in Sources */,
+				D7870BC42AC4750D0080BA89 /* LongformNaddrMentionView.swift in Sources */,
 				4CB55EF5295E679D007FD187 /* UserRelaysView.swift in Sources */,
 				4C363AA228296A7E006E126D /* SearchView.swift in Sources */,
 				D798D2282B085CDA00234419 /* NdbNote+.swift in Sources */,
@@ -6812,6 +6818,7 @@
 				D75154C22EC5910A00BF2CB2 /* NdbUseLock.swift in Sources */,
 				82D6FC3D2CD99F7900C925F4 /* EventShell.swift in Sources */,
 				82D6FC3E2CD99F7900C925F4 /* MentionView.swift in Sources */,
+				82D6FC3E2CD99F7900C925F5 /* LongformNaddrMentionView.swift in Sources */,
 				82D6FC3F2CD99F7900C925F4 /* EventLoaderView.swift in Sources */,
 				5C8F97122EB45FAA009399B1 /* LiveChatTimeline.swift in Sources */,
 				82D6FC402CD99F7900C925F4 /* RepostView.swift in Sources */,
@@ -7249,6 +7256,7 @@
 				D73E5F382C6A97F4007EB227 /* EventShell.swift in Sources */,
 				D73E5F882C6AA661007EB227 /* NostrScript.swift in Sources */,
 				D73E5F392C6A97F4007EB227 /* MentionView.swift in Sources */,
+				D73E5F392C6A97F4007EB228 /* LongformNaddrMentionView.swift in Sources */,
 				D73E5F3A2C6A97F4007EB227 /* EventLoaderView.swift in Sources */,
 				D73E5F3B2C6A97F4007EB227 /* RepostView.swift in Sources */,
 				D73E5F3C2C6A97F4007EB227 /* RepostedEvent.swift in Sources */,

--- a/damus/Core/Nostr/NostrEvent.swift
+++ b/damus/Core/Nostr/NostrEvent.swift
@@ -25,6 +25,22 @@ protocol NostrEventConvertible {
 }
 
 
+/// Reference type for longform articles - can be either naddr or nevent with kind 30023
+enum LongformReference: Equatable {
+    case naddr(NAddr)
+    case nevent(NEvent)
+
+    /// Returns the bech32 encoded string for this reference
+    var bech32: String {
+        switch self {
+        case .naddr(let naddr):
+            return Bech32Object.encode(.naddr(naddr))
+        case .nevent(let nevent):
+            return Bech32Object.encode(.nevent(nevent))
+        }
+    }
+}
+
 enum ValidationResult: Decodable {
     case unknown
     case ok
@@ -851,6 +867,34 @@ func first_longform_naddr_mention(ndb: Ndb, ev: NostrEvent, keypair: Keypair) ->
             }
         })
     })
+}
+
+/// Returns all longform article mentions (naddr or nevent with kind 30023) in the event content.
+func all_longform_mentions(ndb: Ndb, ev: NostrEvent, keypair: Keypair) -> [LongformReference] {
+    return (try? NdbBlockGroup.borrowBlockGroup(event: ev, using: ndb, and: keypair, borrow: { blockGroup in
+        let mentions: [LongformReference] = (try? blockGroup.reduce(initialResult: [LongformReference](), { index, refs, block in
+            switch block {
+            case .mention(let mention):
+                guard let mentionRef = MentionRef(block: mention) else { return .loopContinue }
+                switch mentionRef.nip19 {
+                case .naddr(let naddr):
+                    if naddr.kind == NostrKind.longform.rawValue {
+                        return .loopReturn(refs + [.naddr(naddr)])
+                    }
+                case .nevent(let nevent):
+                    if nevent.kind == NostrKind.longform.rawValue {
+                        return .loopReturn(refs + [.nevent(nevent)])
+                    }
+                default:
+                    break
+                }
+            default:
+                break
+            }
+            return .loopContinue
+        })) ?? []
+        return mentions
+    })) ?? []
 }
 
 func separate_invoices(ndb: Ndb, ev: NostrEvent, keypair: Keypair) -> [Invoice]? {

--- a/damus/Features/Chat/ChatEventView.swift
+++ b/damus/Features/Chat/ChatEventView.swift
@@ -162,11 +162,9 @@ struct ChatEventView: View {
                         .background(DamusColors.adaptableWhite)
                         .clipShape(RoundedRectangle(cornerSize: CGSize(width: 10, height: 10)))
                 }
-                if let longformMention = first_longform_naddr_mention(ndb: damus_state.ndb, ev: event, keypair: damus_state.keypair) {
-                    LongformNaddrMentionView(damus_state: damus_state, naddr: longformMention.ref)
-                        .background(DamusColors.adaptableWhite)
-                        .clipShape(RoundedRectangle(cornerSize: CGSize(width: 10, height: 10)))
-                }
+                LongformMentionsStack(damus_state: damus_state, references: all_longform_mentions(ndb: damus_state.ndb, ev: event, keypair: damus_state.keypair))
+                    .background(DamusColors.adaptableWhite)
+                    .clipShape(RoundedRectangle(cornerSize: CGSize(width: 10, height: 10)))
             }
             .frame(minWidth: 5, alignment: is_ours ? .trailing : .leading)
             .padding(10)

--- a/damus/Features/Chat/ChatEventView.swift
+++ b/damus/Features/Chat/ChatEventView.swift
@@ -162,6 +162,11 @@ struct ChatEventView: View {
                         .background(DamusColors.adaptableWhite)
                         .clipShape(RoundedRectangle(cornerSize: CGSize(width: 10, height: 10)))
                 }
+                if let longformMention = first_longform_naddr_mention(ndb: damus_state.ndb, ev: event, keypair: damus_state.keypair) {
+                    LongformNaddrMentionView(damus_state: damus_state, naddr: longformMention.ref)
+                        .background(DamusColors.adaptableWhite)
+                        .clipShape(RoundedRectangle(cornerSize: CGSize(width: 10, height: 10)))
+                }
             }
             .frame(minWidth: 5, alignment: is_ours ? .trailing : .leading)
             .padding(10)

--- a/damus/Features/DMs/Views/DMView.swift
+++ b/damus/Features/DMs/Views/DMView.swift
@@ -26,13 +26,7 @@ struct DMView: View {
     }
 
     var LongformMention: some View {
-        Group {
-            if let longformMention = first_longform_naddr_mention(ndb: damus_state.ndb, ev: event, keypair: damus_state.keypair) {
-                LongformNaddrMentionView(damus_state: damus_state, naddr: longformMention.ref)
-            } else {
-                EmptyView()
-            }
-        }
+        LongformMentionsStack(damus_state: damus_state, references: all_longform_mentions(ndb: damus_state.ndb, ev: event, keypair: damus_state.keypair))
     }
 
     var dm_options: EventViewOptions {

--- a/damus/Features/DMs/Views/DMView.swift
+++ b/damus/Features/DMs/Views/DMView.swift
@@ -24,7 +24,17 @@ struct DMView: View {
             }
         }
     }
-    
+
+    var LongformMention: some View {
+        Group {
+            if let longformMention = first_longform_naddr_mention(ndb: damus_state.ndb, ev: event, keypair: damus_state.keypair) {
+                LongformNaddrMentionView(damus_state: damus_state, naddr: longformMention.ref)
+            } else {
+                EmptyView()
+            }
+        }
+    }
+
     var dm_options: EventViewOptions {
         /*
         if self.damus_state.settings.translate_dms {
@@ -69,9 +79,10 @@ struct DMView: View {
     var body: some View {
         VStack {
             Mention
+            LongformMention
             DM
         }
-        
+
     }
 }
 

--- a/damus/Features/Events/EventShell.swift
+++ b/damus/Features/Events/EventShell.swift
@@ -43,12 +43,12 @@ struct EventShell<Content: View>: View {
         return first_eref_mention(ndb: ndb, ev: event, keypair: state.keypair)
     }
 
-    func get_longform_naddr_mention(ndb: Ndb) -> Mention<NAddr>? {
+    func get_longform_mentions(ndb: Ndb) -> [LongformReference] {
         if self.options.contains(.nested) || self.options.contains(.no_mentions) {
-            return nil
+            return []
         }
 
-        return first_longform_naddr_mention(ndb: ndb, ev: event, keypair: state.keypair)
+        return all_longform_mentions(ndb: ndb, ev: event, keypair: state.keypair)
     }
 
     var ActionBar: some View {
@@ -87,9 +87,7 @@ struct EventShell<Content: View>: View {
                     MentionView(damus_state: state, mention: mention)
                 }
 
-                if let longformMention = get_longform_naddr_mention(ndb: state.ndb) {
-                    LongformNaddrMentionView(damus_state: state, naddr: longformMention.ref)
-                }
+                LongformMentionsStack(damus_state: state, references: get_longform_mentions(ndb: state.ndb))
 
                 if has_action_bar {
                     ActionBar
@@ -124,10 +122,8 @@ struct EventShell<Content: View>: View {
                     .padding(.horizontal)
             }
 
-            if !options.contains(.no_mentions),
-               let longformMention = get_longform_naddr_mention(ndb: state.ndb)
-            {
-                LongformNaddrMentionView(damus_state: state, naddr: longformMention.ref)
+            if !options.contains(.no_mentions) {
+                LongformMentionsStack(damus_state: state, references: get_longform_mentions(ndb: state.ndb))
                     .padding(.horizontal)
             }
 

--- a/damus/Features/Events/EventShell.swift
+++ b/damus/Features/Events/EventShell.swift
@@ -39,10 +39,18 @@ struct EventShell<Content: View>: View {
         if self.options.contains(.nested) || self.options.contains(.no_mentions) {
             return nil
         }
-        
+
         return first_eref_mention(ndb: ndb, ev: event, keypair: state.keypair)
     }
-    
+
+    func get_longform_naddr_mention(ndb: Ndb) -> Mention<NAddr>? {
+        if self.options.contains(.nested) || self.options.contains(.no_mentions) {
+            return nil
+        }
+
+        return first_longform_naddr_mention(ndb: ndb, ev: event, keypair: state.keypair)
+    }
+
     var ActionBar: some View {
         return EventActionBar(damus_state: state, event: event)
             .padding([.top], 4)
@@ -78,7 +86,11 @@ struct EventShell<Content: View>: View {
                 if let mention = get_mention(ndb: state.ndb) {
                     MentionView(damus_state: state, mention: mention)
                 }
-                
+
+                if let longformMention = get_longform_naddr_mention(ndb: state.ndb) {
+                    LongformNaddrMentionView(damus_state: state, naddr: longformMention.ref)
+                }
+
                 if has_action_bar {
                     ActionBar
                 }
@@ -104,14 +116,21 @@ struct EventShell<Content: View>: View {
             .padding(.horizontal)
 
             content
-            
+
             if !options.contains(.no_mentions),
                let mention = get_mention(ndb: state.ndb)
             {
                 MentionView(damus_state: state, mention: mention)
                     .padding(.horizontal)
             }
-            
+
+            if !options.contains(.no_mentions),
+               let longformMention = get_longform_naddr_mention(ndb: state.ndb)
+            {
+                LongformNaddrMentionView(damus_state: state, naddr: longformMention.ref)
+                    .padding(.horizontal)
+            }
+
             if has_action_bar {
                 ActionBar
                     .padding(.horizontal)

--- a/damus/Features/Events/LongformNaddrMentionView.swift
+++ b/damus/Features/Events/LongformNaddrMentionView.swift
@@ -1,0 +1,155 @@
+//
+//  LongformNaddrMentionView.swift
+//  damus
+//
+//  Created by alltheseas on 2026-01-04.
+//
+
+import SwiftUI
+
+/// A view that displays a longform article preview for an naddr mention.
+/// Loads the referenced addressable event asynchronously and renders it as a LongformPreview card.
+/// Falls back to an abbreviated link if the event cannot be loaded.
+struct LongformNaddrMentionView: View {
+    let damus_state: DamusState
+    let naddr: NAddr
+
+    @State private var loadState: LoadState = .loading
+
+    enum LoadState {
+        case loading
+        case loaded(NostrEvent)
+        case notFound
+    }
+
+    var body: some View {
+        Group {
+            switch loadState {
+            case .loading:
+                loadingView
+            case .loaded(let event):
+                NavigationLink(value: Route.Thread(thread: ThreadModel(event: event, damus_state: damus_state))) {
+                    LongformPreview(state: damus_state, ev: event, options: [.truncate_content, .no_action_bar])
+                }
+                .buttonStyle(.plain)
+            case .notFound:
+                // Fall back to abbreviated text link
+                fallbackLinkView
+            }
+        }
+        .task {
+            await loadEvent()
+        }
+    }
+
+    private var loadingView: some View {
+        HStack {
+            ProgressView()
+                .scaleEffect(0.8)
+            Text("Loading article...")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(DamusColors.neutral1)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.gray.opacity(0.2), lineWidth: 1.0)
+        )
+    }
+
+    private var fallbackLinkView: some View {
+        let bech32 = Bech32Object.encode(.naddr(naddr))
+        return Text("@\(abbrev_identifier(bech32))")
+            .foregroundColor(DamusColors.purple)
+    }
+
+    private func loadEvent() async {
+        // Try to look up the naddr event
+        if let event = await damus_state.nostrNetwork.reader.lookup(naddr: naddr) {
+            await MainActor.run {
+                loadState = .loaded(event)
+            }
+        } else {
+            await MainActor.run {
+                loadState = .notFound
+            }
+        }
+    }
+}
+
+/// A view that displays a longform article preview for a nevent mention.
+/// Loads the referenced event by note ID and renders it as a LongformPreview card.
+struct LongformNeventMentionView: View {
+    let damus_state: DamusState
+    let nevent: NEvent
+
+    @State private var loadState: LoadState = .loading
+
+    enum LoadState {
+        case loading
+        case loaded(NostrEvent)
+        case notFound
+    }
+
+    var body: some View {
+        Group {
+            switch loadState {
+            case .loading:
+                loadingView
+            case .loaded(let event):
+                NavigationLink(value: Route.Thread(thread: ThreadModel(event: event, damus_state: damus_state))) {
+                    LongformPreview(state: damus_state, ev: event, options: [.truncate_content, .no_action_bar])
+                }
+                .buttonStyle(.plain)
+            case .notFound:
+                // Fall back to abbreviated text link
+                fallbackLinkView
+            }
+        }
+        .task {
+            await loadEvent()
+        }
+    }
+
+    private var loadingView: some View {
+        HStack {
+            ProgressView()
+                .scaleEffect(0.8)
+            Text("Loading article...")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .background(DamusColors.neutral1)
+        .cornerRadius(10)
+        .overlay(
+            RoundedRectangle(cornerRadius: 10)
+                .stroke(Color.gray.opacity(0.2), lineWidth: 1.0)
+        )
+    }
+
+    private var fallbackLinkView: some View {
+        let bech32 = Bech32Object.encode(.nevent(nevent))
+        return Text("@\(abbrev_identifier(bech32))")
+            .foregroundColor(DamusColors.purple)
+    }
+
+    private func loadEvent() async {
+        // Try to look up the event by note ID
+        if let lender = try? await damus_state.nostrNetwork.reader.lookup(noteId: nevent.noteid) {
+            lender.justUseACopy { event in
+                Task { @MainActor in
+                    loadState = .loaded(event)
+                }
+            }
+        } else {
+            await MainActor.run {
+                loadState = .notFound
+            }
+        }
+    }
+}

--- a/damus/Features/Events/LongformNaddrMentionView.swift
+++ b/damus/Features/Events/LongformNaddrMentionView.swift
@@ -2,58 +2,83 @@
 //  LongformNaddrMentionView.swift
 //  damus
 //
-//  Created by alltheseas on 2026-01-04.
+//  Created by alltheseas + jb55 on 2026-01-04.
 //
 
 import SwiftUI
 
-/// A view that dispatches to the appropriate longform mention view based on reference type.
+/// A view that displays a longform article preview for a reference (naddr or nevent).
+/// Loads asynchronously and renders as a LongformPreview card, with a text fallback if not found.
 struct LongformMentionView: View {
     let damus_state: DamusState
     let reference: LongformReference
 
+    @State private var loadState: LoadState = .loading
+
+    private enum LoadState {
+        case loading
+        case loaded(NostrEvent)
+        case notFound
+    }
+
     var body: some View {
+        Group {
+            switch loadState {
+            case .loading:
+                loadingView
+
+            case .loaded(let event):
+                NavigationLink(
+                    value: Route.Thread(thread: ThreadModel(event: event, damus_state: damus_state))
+                ) {
+                    LongformPreview(state: damus_state, ev: event, options: [.truncate_content, .no_action_bar])
+                }
+                .buttonStyle(.plain)
+
+            case .notFound:
+                fallbackLinkView
+            }
+        }
+        .task {
+            await loadEvent()
+        }
+    }
+
+    private var fallbackLinkView: some View {
+        Text("@\(abbrev_identifier(bech32))")
+            .foregroundColor(DamusColors.purple)
+    }
+
+    private var bech32: String {
         switch reference {
         case .naddr(let naddr):
-            LongformNaddrMentionView(damus_state: damus_state, naddr: naddr)
+            return Bech32Object.encode(.naddr(naddr))
         case .nevent(let nevent):
-            LongformNeventMentionView(damus_state: damus_state, nevent: nevent)
+            return Bech32Object.encode(.nevent(nevent))
         }
     }
-}
 
-/// A view that displays a longform article preview for an naddr mention.
-/// Loads the referenced addressable event asynchronously and renders it as a LongformPreview card.
-/// Falls back to an abbreviated link if the event cannot be loaded.
-struct LongformNaddrMentionView: View {
-    let damus_state: DamusState
-    let naddr: NAddr
-
-    @State private var loadState: LoadState = .loading
-
-    enum LoadState {
-        case loading
-        case loaded(NostrEvent)
-        case notFound
-    }
-
-    var body: some View {
-        Group {
-            switch loadState {
-            case .loading:
-                loadingView
-            case .loaded(let event):
-                NavigationLink(value: Route.Thread(thread: ThreadModel(event: event, damus_state: damus_state))) {
-                    LongformPreview(state: damus_state, ev: event, options: [.truncate_content, .no_action_bar])
-                }
-                .buttonStyle(.plain)
-            case .notFound:
-                // Fall back to abbreviated text link
-                fallbackLinkView
+    private func loadEvent() async {
+        switch reference {
+        case .naddr(let naddr):
+            if let event = await damus_state.nostrNetwork.reader.lookup(naddr: naddr) {
+                await MainActor.run { loadState = .loaded(event) }
+            } else {
+                await MainActor.run { loadState = .notFound }
             }
-        }
-        .task {
-            await loadEvent()
+
+        case .nevent(let nevent):
+            if let lender = try? await damus_state.nostrNetwork.reader.lookup(noteId: nevent.noteid) {
+                // Preserve the existing copy semantics
+                let event: NostrEvent = await withCheckedContinuation { continuation in
+                    lender.justUseACopy { ev in
+                        continuation.resume(returning: ev)
+                    }
+                }
+                await MainActor.run { loadState = .loaded(event) }
+            } else {
+                await MainActor.run { loadState = .notFound }
+            }
         }
     }
 
@@ -73,99 +98,6 @@ struct LongformNaddrMentionView: View {
             RoundedRectangle(cornerRadius: 10)
                 .stroke(Color.gray.opacity(0.2), lineWidth: 1.0)
         )
-    }
-
-    private var fallbackLinkView: some View {
-        let bech32 = Bech32Object.encode(.naddr(naddr))
-        return Text("@\(abbrev_identifier(bech32))")
-            .foregroundColor(DamusColors.purple)
-    }
-
-    private func loadEvent() async {
-        // Try to look up the naddr event
-        if let event = await damus_state.nostrNetwork.reader.lookup(naddr: naddr) {
-            await MainActor.run {
-                loadState = .loaded(event)
-            }
-        } else {
-            await MainActor.run {
-                loadState = .notFound
-            }
-        }
-    }
-}
-
-/// A view that displays a longform article preview for a nevent mention.
-/// Loads the referenced event by note ID and renders it as a LongformPreview card.
-struct LongformNeventMentionView: View {
-    let damus_state: DamusState
-    let nevent: NEvent
-
-    @State private var loadState: LoadState = .loading
-
-    enum LoadState {
-        case loading
-        case loaded(NostrEvent)
-        case notFound
-    }
-
-    var body: some View {
-        Group {
-            switch loadState {
-            case .loading:
-                loadingView
-            case .loaded(let event):
-                NavigationLink(value: Route.Thread(thread: ThreadModel(event: event, damus_state: damus_state))) {
-                    LongformPreview(state: damus_state, ev: event, options: [.truncate_content, .no_action_bar])
-                }
-                .buttonStyle(.plain)
-            case .notFound:
-                // Fall back to abbreviated text link
-                fallbackLinkView
-            }
-        }
-        .task {
-            await loadEvent()
-        }
-    }
-
-    private var loadingView: some View {
-        HStack {
-            ProgressView()
-                .scaleEffect(0.8)
-            Text("Loading article...")
-                .font(.caption)
-                .foregroundColor(.secondary)
-        }
-        .padding()
-        .frame(maxWidth: .infinity)
-        .background(DamusColors.neutral1)
-        .cornerRadius(10)
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(Color.gray.opacity(0.2), lineWidth: 1.0)
-        )
-    }
-
-    private var fallbackLinkView: some View {
-        let bech32 = Bech32Object.encode(.nevent(nevent))
-        return Text("@\(abbrev_identifier(bech32))")
-            .foregroundColor(DamusColors.purple)
-    }
-
-    private func loadEvent() async {
-        // Try to look up the event by note ID
-        if let lender = try? await damus_state.nostrNetwork.reader.lookup(noteId: nevent.noteid) {
-            lender.justUseACopy { event in
-                Task { @MainActor in
-                    loadState = .loaded(event)
-                }
-            }
-        } else {
-            await MainActor.run {
-                loadState = .notFound
-            }
-        }
     }
 }
 
@@ -178,18 +110,8 @@ struct LongformPreviewCard: View {
 
     var body: some View {
         ZStack(alignment: .topTrailing) {
-            previewContent
+            LongformMentionView(damus_state: damus_state, reference: reference)
             deleteButton
-        }
-    }
-
-    @ViewBuilder
-    private var previewContent: some View {
-        switch reference {
-        case .naddr(let naddr):
-            LongformNaddrMentionView(damus_state: damus_state, naddr: naddr)
-        case .nevent(let nevent):
-            LongformNeventMentionView(damus_state: damus_state, nevent: nevent)
         }
     }
 

--- a/damus/Features/Events/SelectedEventView.swift
+++ b/damus/Features/Events/SelectedEventView.swift
@@ -50,7 +50,9 @@ struct SelectedEventView: View {
                 EventBody(damus_state: damus, event: event, size: size, options: [.wide])
 
                 Mention
-                
+
+                LongformMention
+
                 Text(verbatim: "\(format_date(created_at: event.created_at))")
                     .padding([.top, .leading, .trailing])
                     .font(.footnote)
@@ -84,6 +86,15 @@ struct SelectedEventView: View {
         Group {
             if let mention = first_eref_mention(ndb: damus.ndb, ev: event, keypair: damus.keypair) {
                 MentionView(damus_state: damus, mention: mention)
+                    .padding(.horizontal)
+            }
+        }
+    }
+
+    var LongformMention: some View {
+        Group {
+            if let longformMention = first_longform_naddr_mention(ndb: damus.ndb, ev: event, keypair: damus.keypair) {
+                LongformNaddrMentionView(damus_state: damus, naddr: longformMention.ref)
                     .padding(.horizontal)
             }
         }

--- a/damus/Features/Events/SelectedEventView.swift
+++ b/damus/Features/Events/SelectedEventView.swift
@@ -92,12 +92,8 @@ struct SelectedEventView: View {
     }
 
     var LongformMention: some View {
-        Group {
-            if let longformMention = first_longform_naddr_mention(ndb: damus.ndb, ev: event, keypair: damus.keypair) {
-                LongformNaddrMentionView(damus_state: damus, naddr: longformMention.ref)
-                    .padding(.horizontal)
-            }
-        }
+        LongformMentionsStack(damus_state: damus, references: all_longform_mentions(ndb: damus.ndb, ev: event, keypair: damus.keypair))
+            .padding(.horizontal)
     }
 }
 


### PR DESCRIPTION
## Summary

- Add preview cards for longform article (kind 30023) references in notes
- Support both `naddr` and `nevent` reference formats
- Show previews in feed, thread, chat, and DM views
- Add compose view support with draft persistence and duplicate prevention
- Support multiple longform references with vertical stack layout

## Test plan

- [ ] Paste `naddr1...` referencing a longform article in compose view → preview card appears
- [ ] Paste `nevent1...` referencing a kind 30023 event → preview card appears
- [ ] View note containing longform reference → preview card shown, inline text suppressed
- [ ] Multiple longform refs in note → vertical stack of preview cards
- [ ] Dismiss and reopen compose with longform ref → reference preserved in draft
- [ ] Type same reference twice → no duplicates in final post

Closes damus-io/damus#2798

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Longform article mentions supported across messages, DMs, event threads and selected-event views.
  * Interactive longform preview cards with loading/fallback states and navigable links to full threads.
  * Horizontal carousel in compose and read-only contexts; previews can be deleted before posting.
  * Compose flow auto-extracts, previews, persists and appends longform references; inline mention text is suppressed when previews are shown.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->