### PR TITLE
feat: add maximum cache size setting with automatic eviction

### DIFF
--- a/damus/ContentView.swift
+++ b/damus/ContentView.swift
@@ -506,6 +506,9 @@ struct ContentView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { obj in
             print("txn: 📙 DAMUS ACTIVE NOTIFY")
+            DispatchQueue.global(qos: .utility).async {
+                DamusCacheManager.shared.enforce_cache_limits()
+            }
             Task {
                 if damus_state.ndb.reopen() {
                     print("txn: NOSTRDB REOPENED")

--- a/damus/Core/Storage/DamusCacheManager.swift
+++ b/damus/Core/Storage/DamusCacheManager.swift
@@ -10,7 +10,52 @@ import Kingfisher
 
 struct DamusCacheManager {
     static var shared: DamusCacheManager = DamusCacheManager()
-    
+    static let max_cache_size_gb_key = "max_cache_size_gb"
+
+    /// Enforces the user's maximum cache size budget.
+    /// Splits the budget 2/3 to images, 1/3 to video.
+    /// Safe to call from any thread.
+    func enforce_cache_limits() {
+        let gb = UserDefaults.standard.integer(forKey: DamusCacheManager.max_cache_size_gb_key)
+        guard gb > 0 else { return }
+
+        let budget = UInt64(gb) * 1_000_000_000
+
+        // Video cache gets 1/3 of budget — trim oldest files to fit
+        enforce_video_size_limit(max_bytes: budget / 3)
+
+        // Image cache gets 2/3 of budget
+        let image_limit = UInt(budget * 2 / 3)
+        KingfisherManager.shared.cache.diskStorage.config.sizeLimit = image_limit
+        KingfisherManager.shared.cache.cleanExpiredDiskCache()
+    }
+
+    /// Deletes oldest video cache files until total size is within the given budget.
+    private func enforce_video_size_limit(max_bytes: UInt64) {
+        guard let cache_dir = FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first?.appendingPathComponent("video_cache") else { return }
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(at: cache_dir, includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey], options: .skipsHiddenFiles) else { return }
+
+        var entries: [(url: URL, date: Date, size: UInt64)] = []
+        var total: UInt64 = 0
+        for file in files {
+            guard let values = try? file.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
+                  let date = values.contentModificationDate,
+                  let size = values.fileSize else { continue }
+            let file_size = UInt64(size)
+            entries.append((url: file, date: date, size: file_size))
+            total += file_size
+        }
+
+        guard total > max_bytes else { return }
+        entries.sort { $0.date < $1.date }
+        for entry in entries {
+            guard total > max_bytes else { break }
+            try? fm.removeItem(at: entry.url)
+            total -= entry.size
+        }
+    }
+
     func clear_cache(damus_state: DamusState, completion: (() -> Void)? = nil) {
         Log.info("Clearing all caches", for: .storage)
         clear_kingfisher_cache(completion: {

--- a/damus/Core/Storage/DamusCacheManager.swift
+++ b/damus/Core/Storage/DamusCacheManager.swift
@@ -17,7 +17,11 @@ struct DamusCacheManager {
     /// Safe to call from any thread.
     func enforce_cache_limits() {
         let gb = UserDefaults.standard.integer(forKey: DamusCacheManager.max_cache_size_gb_key)
-        guard gb > 0 else { return }
+        guard gb > 0 else {
+            // No limit — clear any previously set cap
+            KingfisherManager.shared.cache.diskStorage.config.sizeLimit = 0
+            return
+        }
 
         let budget = UInt64(gb) * 1_000_000_000
 

--- a/damus/Features/Settings/Views/StorageSettingsView.swift
+++ b/damus/Features/Settings/Views/StorageSettingsView.swift
@@ -62,6 +62,7 @@ struct StorageSettingsView: View {
     @State var showing_compact_alert: Bool = false
     @State fileprivate var purge_scheduling_state: PurgeSchedulingState = .not_scheduled
     @State var showing_purge_alert: Bool = false
+    @State private var max_cache_size_gb: Int = UserDefaults.standard.integer(forKey: DamusCacheManager.max_cache_size_gb_key)
     
     /// Storage categories with cumulative ranges for angle selection (iOS 17+)
     private var categoryRanges: [(category: String, range: Range<Double>)] {
@@ -196,6 +197,30 @@ struct StorageSettingsView: View {
                     }
                 }
                 
+                // Maximum Cache Size
+                Section(footer: Text("Automatically removes old cached images and videos to stay within this limit.", comment: "Footer explaining the maximum cache size setting.")) {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Maximum Cache Size", comment: "Label for the maximum cache size picker.")
+                        Picker("", selection: $max_cache_size_gb) {
+                            Text("5 GB").tag(5)
+                            Text("16 GB").tag(16)
+                            Text("32 GB").tag(32)
+                            Text("No Limit", comment: "Option to disable cache size limit.").tag(0)
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                    .padding(.vertical, 4)
+                }
+                .onChange(of: max_cache_size_gb) { new_value in
+                    UserDefaults.standard.set(new_value, forKey: DamusCacheManager.max_cache_size_gb_key)
+                    DispatchQueue.global(qos: .utility).async {
+                        DamusCacheManager.shared.enforce_cache_limits()
+                        DispatchQueue.main.async {
+                            loadStorageStats()
+                        }
+                    }
+                }
+
                 // Clear Cache Section
                 Section {
                     self.ClearCacheButton

--- a/damus/Models/VideoCache.swift
+++ b/damus/Models/VideoCache.swift
@@ -105,6 +105,38 @@ struct VideoCache {
         }
     }
     
+    /// Deletes oldest cached videos until total size is within the given budget.
+    /// Runs synchronously on the caller's thread.
+    func enforce_size_limit(max_bytes: UInt64) {
+        let file_manager = FileManager.default
+        guard let files = try? file_manager.contentsOfDirectory(at: self.cache_url, includingPropertiesForKeys: [.contentModificationDateKey, .fileSizeKey], options: .skipsHiddenFiles) else {
+            return
+        }
+
+        var entries: [(url: URL, date: Date, size: UInt64)] = []
+        var total: UInt64 = 0
+
+        for file in files {
+            guard let values = try? file.resourceValues(forKeys: [.contentModificationDateKey, .fileSizeKey]),
+                  let date = values.contentModificationDate,
+                  let size = values.fileSize else { continue }
+            let file_size = UInt64(size)
+            entries.append((url: file, date: date, size: file_size))
+            total += file_size
+        }
+
+        guard total > max_bytes else { return }
+
+        // Sort oldest first
+        entries.sort { $0.date < $1.date }
+
+        for entry in entries {
+            guard total > max_bytes else { break }
+            try? file_manager.removeItem(at: entry.url)
+            total -= entry.size
+        }
+    }
+
     /// Hashes the URL using SHA-256
     private func hash_url(_ url: URL) -> String {
         let data = Data(url.absoluteString.utf8)

--- a/damus/damusApp.swift
+++ b/damus/damusApp.swift
@@ -120,10 +120,9 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
             KingfisherManager.shared.cache = cache
         }
 
-        let gb = UserDefaults.standard.integer(forKey: DamusCacheManager.max_cache_size_gb_key)
-        if gb > 0 {
-            let budget = UInt(gb) * 1_000_000_000
-            KingfisherManager.shared.cache.diskStorage.config.sizeLimit = budget * 2 / 3
+        // Apply cache size limits and trim oversized caches on startup
+        DispatchQueue.global(qos: .utility).async {
+            DamusCacheManager.shared.enforce_cache_limits()
         }
     }
 }

--- a/damus/damusApp.swift
+++ b/damus/damusApp.swift
@@ -82,7 +82,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         registerNotificationCategories()
         ImageCacheMigrations.migrateKingfisherCacheIfNeeded()
         configureKingfisherCache()
-        
+
         return true
     }
     
@@ -118,6 +118,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         let cachePath = ImageCacheMigrations.kingfisherCachePath()
         if let cache = try? ImageCache(name: "sharedCache", cacheDirectoryURL: cachePath) {
             KingfisherManager.shared.cache = cache
+        }
+
+        let gb = UserDefaults.standard.integer(forKey: DamusCacheManager.max_cache_size_gb_key)
+        if gb > 0 {
+            let budget = UInt(gb) * 1_000_000_000
+            KingfisherManager.shared.cache.diskStorage.config.sizeLimit = budget * 2 / 3
         }
     }
 }


### PR DESCRIPTION
## Summary
- Add Telegram-style "Maximum Cache Size" picker in Settings > Storage (5 GB, 16 GB, 32 GB, No Limit)
- Budget splits 2/3 to Kingfisher image cache, 1/3 to video cache; oldest files evicted first
- Enforcement runs on cold launch, app foreground, and immediately when the setting changes
- Selecting "No Limit" resets Kingfisher `sizeLimit` to 0 immediately (no stale cap)
- Uses `UserDefaults.standard` with a fixed key (device-global, not per-pubkey)

## Test plan
- [ ] Set "Maximum Cache Size" to 5 GB — verify cache is trimmed and storage view refreshes
- [ ] Background then foreground the app — verify enforcement runs
- [ ] Set "No Limit" — verify no eviction runs and sizeLimit is cleared
- [ ] Cold launch with a limit set — verify oversized caches are trimmed on startup
- [ ] Build succeeds with no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)